### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and operators, and also the ability to format the output into any arbitrary JSON
 
 
 ##Tutorial
-A tutorial on the JSONata language is available [here](./tutorial.md)
+A tutorial on the JSONata language is available [here](tutorial.md)
 
 ##Errors
 
@@ -25,8 +25,8 @@ For example:
 `{ "position": 16, "token": "}", "value": "]", "message": "Syntax error: expected ']' got '}' at column 16" }`
 
 ##More Information
-Tutorial [tutorial.md](./tutorial.md)
-Function library [functions.md](./functions.md)
+Tutorial [tutorial.md](tutorial.md)
+Function library [functions.md](functions.md)
 
 ## Contributing changes
-See the [CONTRIBUTING.md](./CONTRIBUTING.md) for details of how to contribute to this repo.
+See the [CONTRIBUTING.md](CONTRIBUTING.md) for details of how to contribute to this repo.


### PR DESCRIPTION
The links in `README.md` are absolute but need to be relative to they work on npmjs