### PR TITLE
Add david-dm dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jsonata-js/jsonata.svg)](https://travis-ci.org/jsonata-js/jsonata)
 [![Coverage Status](https://coveralls.io/repos/github/jsonata-js/jsonata/badge.svg?branch=master)](https://coveralls.io/github/jsonata-js/jsonata?branch=master)
+[![Dependency Status](https://david-dm.org/jsonata-js/jsonata.svg)](https://david-dm.org/jsonata-js/jsonata)
 
 JSON query and transformation language
 


### PR DESCRIPTION
This makes is clear that the project currently has no (dev) dependencies, and would highlight any outdated ones if they were ever added.