### PR TITLE
Add an npm download numbers badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # JSONata
 
+[![Download Status](http://img.shields.io/npm/dt/jsonata.svg)](https://www.npmjs.org/package/jsonata)
 [![Build Status](https://travis-ci.org/jsonata-js/jsonata.svg)](https://travis-ci.org/jsonata-js/jsonata)
 [![Coverage Status](https://coveralls.io/repos/github/jsonata-js/jsonata/badge.svg?branch=master)](https://coveralls.io/github/jsonata-js/jsonata?branch=master)
 


### PR DESCRIPTION
This displays the number of downloads and also is a handy link to the `npm` page from GitHub.