### PR TITLE
cast functions: undefined arg returns undefined

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -82,12 +82,24 @@ Casts the `arg` parameter to a number using the following casting rules
    - Strings that contain a sequence of characters that represent a legal JSON number are converted to that number
    - All other values cause an error to be thrown.
 
+#### `$abs(number)` - to be implemented
+#### `$round(number)` - to be implemented
+
+Rounds up to the nearest integer
+
+#### `$roundHalfToEven(number)` - to be implemented
+
+  [Round half to even](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even) Commonly used in financial calculations.
+
+#### `$power(base, exponent)` - to be implemented
+
+### Numeric aggregation functions
+
 #### `$sum(array)`
 
 Returns the arithmetic sum of an array of numbers. 
 It is an error if the input array contains an item which isn't a number.
 
-#### `$abs(number)` - to be implemented
 #### `$max(array)`
 
 Returns the maximum number in an array of numbers. 
@@ -98,20 +110,10 @@ It is an error if the input array contains an item which isn't a number.
 Returns the minimum number in an array of numbers. 
 It is an error if the input array contains an item which isn't a number.
 
-#### `$round(number)` - to be implemented
-
-Rounds up to the nearest integer
-
-#### `$roundHalfToEven(number)` - to be implemented
-
-  [Round half to even](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even) Commonly used in financial calculations.
-
 #### `$average(array)`
 
 Returns the mean value of an array of numbers. 
 It is an error if the input array contains an item which isn't a number.
-
-#### `$power(base, exponent)` - to be implemented
 
 ### Boolean functions
 

--- a/jsonata.js
+++ b/jsonata.js
@@ -1945,6 +1945,11 @@ function functionString(arg) {
         };
     }
 
+    // undefined inputs always return undefined
+    if(typeof arg === 'undefined') {
+        return undefined;
+    }
+
     if (typeof arg === 'string') {
         // already a string
         str = arg;
@@ -2306,6 +2311,11 @@ function functionNumber(arg) {
         };
     }
 
+    // undefined inputs always return undefined
+    if(typeof arg === 'undefined') {
+        return undefined;
+    }
+
     if (typeof arg === 'number') {
         // already a number
         result = arg;
@@ -2342,6 +2352,11 @@ function functionBoolean(arg) {
             message: 'The boolean function expects one argument',
             stack: (new Error()).stack
         };
+    }
+
+    // undefined inputs always return undefined
+    if(typeof arg === 'undefined') {
+        return undefined;
     }
 
     var result = false;

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -3921,6 +3921,15 @@ describe('Evaluator - functions: number', function () {
         });
     });
 
+    describe('$number(Account.blah)', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$number(Account.blah)');
+            var result = expr.evaluate(testdata2);
+            var expected = undefined;
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
     describe('$number(null)', function () {
         it('should throw error', function () {
             var expr = jsonata('$number(null)');
@@ -4241,7 +4250,7 @@ describe('Evaluator - functions: boolean', function () {
         it('should return result object', function () {
             var expr = jsonata('$boolean(Account.blah)');
             var result = expr.evaluate(testdata2);
-            var expected = false;
+            var expected = undefined;
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });


### PR DESCRIPTION
Added to the casting functions the usual condition that invoking them on undefined (no match) should return undefined