### PR TITLE
Remove dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/jsonata-js/jsonata.svg)](https://travis-ci.org/jsonata-js/jsonata)
 [![Coverage Status](https://coveralls.io/repos/github/jsonata-js/jsonata/badge.svg?branch=master)](https://coveralls.io/github/jsonata-js/jsonata?branch=master)
-[![Dependency Status](https://david-dm.org/jsonata-js/jsonata.svg)](https://david-dm.org/jsonata-js/jsonata)
 
 JSON query and transformation language
 


### PR DESCRIPTION
The `david-dm` dependency badge seems to not be working more than it is; I think their servers are struggling, but in turn it just gives an ugly `image not found` on the front page of this repo.

As there are no dependencies, the badge is only indicating as such, and is not actually making anyone aware of out of date dependencies (as you would see when it's used elsewhere). I think it should be removed for now, and could return in the future if any dependencies are added.