### PR TITLE
Use function version of 'use strict'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
       }
     }],
     "semi": ["error", "always"],
-    "strict": ["error", "global"],
+    "strict": ["error", "function"],
     "valid-jsdoc": ["error", {"requireReturn": false}]
   }
 }

--- a/jsonata.js
+++ b/jsonata.js
@@ -4,7 +4,6 @@
  *   This project is licensed under the MIT License, see LICENSE
  */
 
-'use strict';
 /**
  * @module JSONata
  * @description JSON query and transformation language
@@ -17,6 +16,8 @@
  * @returns {{evaluate: evaluate, assign: assign}} Evaluated expression
  */
 var jsonata = (function() {
+    'use strict';
+
     var operators = {
         '.': 75,
         '[': 80,
@@ -483,7 +484,7 @@ var jsonata = (function() {
             return this;
         });
 
-    // object constructor
+        // object constructor
         prefix("{", function () {
             var a = [];
             if (node.id !== "}") {
@@ -504,7 +505,7 @@ var jsonata = (function() {
             return this;
         });
 
-    // array constructor
+        // array constructor
         prefix("[", function () {
             var a = [];
             if (node.id !== "]") {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  // Rules ammendments
+  "rules": {
+    "strict": ["error", "global"],
+  }
+}


### PR DESCRIPTION
The `'use strict'` directive is only recognised as the beginning of a script or function.  If JSONata is merged with other files using `browserify` or similar technology, the global `'use strict'` at the top of the file will cease to apply as it will no longer be the first statement in the file.  Therefore it is safer to put `'use strict'` at the start of the JSONata main function, so that it is guaranteed to apply to that function and other functions defined within it.  This is not necessary for the test code, which retains a global `'use strict'`.