### PR TITLE
ESLint updates, principally to ban eval()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,12 +17,15 @@
   // Additional rules
   "rules": {
     "array-bracket-spacing": ["error", "never"],
+    "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "dot-notation": "error",
     "ideal/no-tabs-in-file": "error",
     "indent": ["error", 4, {"SwitchCase": 1}],
     "max-len": ["error", 1000, {"ignoreComments": true}],
     "new-cap": ["error", {"capIsNewExceptions": ["Router"]}],
-    "no-console": "off",
+    "no-console": "error",
+    "no-eval": "error",
+    "no-implied-eval": "error",
     "no-floating-decimal": "error",
     "no-lonely-if": "error",
     "no-spaced-func": "error",


### PR DESCRIPTION
Also:
- banned used of `console`, e.g. `console.log()`
- currently the project follows the `1tbs` brace style, so added a rule to stop anyone doing anything different in the future