### PR TITLE
Changes to behaviour of object constructor and result arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,52 @@
 JSON query and transformation language
 
 ##Introduction
-The primary purpose of this language is to extract values from JSON documents, with the
-additional capabilities to combine these values using a set of basic functions
-and operators, and also the ability to format the output into any arbitrary JSON structure.
+JSONata is a lightweight query and transformation language for JSON data.
+Inspired by the 'location path' semantics of XPath 3.1, it allows sophisticated
+queries to be expressed in a compact and intuitive notation.  A rich complement of built in
+operators and functions is provided for manipulating and combining extracted
+data, and the results of queries can be formatted into any JSON output structure
+using familiar JSON object and array syntax.
+Coupled with the facility to create user defined functions, advanced expressions
+can be built to tackle any JSON query and transformation task.
+
+<p><iframe width="400" height="300" src="https://www.youtube.com/embed/ZBaK40rtIBM" frameborder="0" allowfullscreen></iframe><br />
+<br /></p>
+
+Try it out at [http://try.jsonata.org/](http://try.jsonata.org/)
 
 ##Install
 - `npm install jsonata`
 
 ##Usage
-In node.js (works in v0.10 and later):
-```
+In node.js:
+```javascript
 var jsonata = require("jsonata");
 var data = { "example": [ {"value": 4}, {"value": 7}, {"value": 13}] };
 var expression = "$sum(example.value)";
 var result = jsonata(expression).evaluate(data);  // returns 24
 ```
 
-In a browser (works in latest Chrome, Firefox, Safari):
-```
+In a browser:
+```html
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>JSONata test</title>
     <script src="lib/jsonata.js"></script>
+    <script>
+        function greeting() {
+            var json = JSON.parse(document.getElementById('json').value);
+            var result = jsonata('"Hello, " & name').evaluate(json);
+            document.getElementById('greeting').innerHTML = result;
+        }
+    </script>
 </head>
 <body>
-<button onclick="alert(jsonata('[1..10]').evaluate())">Click me</button>
+    <textarea id="json">{ "name": "Wilbur" }</textarea>
+    <button onclick="greeting()">Click me</button>
+    <p id="greeting"></p>
 </body>
 </html>
 ```
@@ -65,11 +84,12 @@ and any other relevant information, including a meaningful message string.
 
 For example:
 
-`{ "position": 16, "token": "}", "value": "]", "message": "Syntax error: expected ']' got '}' at column 16" }`
+`{ "position": 16, "token": "}", "value": "]", "message": "Syntax error: expected ']' got '}'" }`
 
 ##More Information
 Tutorial [tutorial.md](tutorial.md)
 Function library [functions.md](functions.md)
+JSONata [Tech Talk](https://developer.ibm.com/open/videos/dw-open-tech-talk-jsonata/) 
 
 ## Contributing
 See the [CONTRIBUTING.md](CONTRIBUTING.md) for details of how to contribute to this repo.

--- a/jsonata.js
+++ b/jsonata.js
@@ -472,33 +472,13 @@ var parser = function (source) {
         return this;
     });
 
-// object constructor
-    prefix("{", function () {
-        var a = [];
-        if (node.id !== "}") {
-            for (;;) {
-                var n = expression(0);
-                advance(":");
-                var v = expression(0);
-                a.push([n, v]); // holds an array of name/value expression pairs
-                if (node.id !== ",") {
-                    break;
-                }
-                advance(",");
-            }
-        }
-        advance("}");
-        this.lhs = a;
-        this.type = "unary";
-        return this;
-    });
-
 // array constructor
     prefix("[", function () {
         var a = [];
         if (node.id !== "]") {
             for (;;) {
                 var item = expression(0);
+//                item.keepArray = true;
                 if (node.id === "..") {
                     // range operator
                     var range = {type: "binary", value: "..", position: node.position, lhs: item};
@@ -521,21 +501,57 @@ var parser = function (source) {
 
     // filter - predicate or array index
     infix("[", operators['['], function (left) {
-        this.lhs = left;
-        this.rhs = expression(operators[']']);
-        this.type = 'binary';
-        advance("]");
-        return this;
+        if(node.id === "]") {
+            // empty predicate means maintain singleton arrays in the output
+            var step = left;
+            while(step && step.type === 'binary' && step.value === '[') {
+                step = step.lhs;
+            }
+            step.keepArray = true;
+            advance("]");
+            return left;
+        } else {
+            this.lhs = left;
+            this.rhs = expression(operators[']']);
+            this.type = 'binary';
+            advance("]");
+            return this;
+        }
     });
 
-    // aggregator
-    infix("{", operators['{'], function (left) {
-        this.lhs = left;
-        this.rhs = expression(operators['}']);
-        this.type = 'binary';
+    var objectParser = function (left) {
+        var a = [];
+        if (node.id !== "}") {
+            for (;;) {
+                var n = expression(0);
+                advance(":");
+                var v = expression(0);
+                a.push([n, v]); // holds an array of name/value expression pairs
+                if (node.id !== ",") {
+                    break;
+                }
+                advance(",");
+            }
+        }
         advance("}");
+        if(typeof left === 'undefined') {
+            // NUD - unary prefix form
+            this.lhs = a;
+            this.type = "unary";
+        } else {
+            // LED - binary infix form
+            this.lhs = left;
+            this.rhs = a;
+            this.type = 'binary';
+        }
         return this;
-    });
+    };
+
+    // object constructor
+    prefix("{", objectParser);
+
+    // object grouping
+    infix("{", operators['{'], objectParser);
 
     // if/then/else ternary operator ?:
     infix("?", operators['?'], function (left) {
@@ -589,13 +605,16 @@ var parser = function (source) {
             case 'binary':
                 switch (expr.value) {
                     case '.':
-                        var step = post_parse(expr.lhs);
-                        if (Array.isArray(step)) {
-                            Array.prototype.push.apply(result, step);
+                        var lstep = post_parse(expr.lhs);
+                        if (lstep.type === 'path') {
+                            Array.prototype.push.apply(result, lstep);
                         } else {
-                            result.push(step);
+                            result.push(lstep);
                         }
-                        var rest = [post_parse(expr.rhs)];
+                        var rest = post_parse(expr.rhs);
+                        if(rest.type !== 'path') {
+                            rest = [rest];
+                        }
                         Array.prototype.push.apply(result, rest);
                         result.type = 'path';
                         break;
@@ -604,31 +623,41 @@ var parser = function (source) {
                         // LHS is a step or a predicated step
                         // RHS is the predicate expr
                         result = post_parse(expr.lhs);
-                        if (typeof result.aggregate !== 'undefined') {
+                        var step = result;
+                        if(result.type === 'path') {
+                            step = result[result.length - 1];
+                        }
+                        if (typeof step.group !== 'undefined') {
                             throw {
-                                message: 'A predicate cannot follow an aggregate in a step. Error at column: ' + expr.position,
+                                message: 'A predicate cannot follow a grouping expression in a step. Error at column: ' + expr.position,
                                 stack: (new Error()).stack,
                                 position: expr.position
                             };
                         }
-                        if (typeof result.predicate === 'undefined') {
-                            result.predicate = [];
+                        if (typeof step.predicate === 'undefined') {
+                            step.predicate = [];
                         }
-                        result.predicate.push(post_parse(expr.rhs));
+                        step.predicate.push(post_parse(expr.rhs));
                         break;
                     case '{':
-                        // aggregate
+                        // group-by
                         // LHS is a step or a predicated step
-                        // RHS is the predicate expr
+                        // RHS is the object constructor expr
                         result = post_parse(expr.lhs);
-                        if (typeof result.aggregate !== 'undefined') {
+                        if (typeof result.group !== 'undefined') {
                             throw {
-                                message: 'Each step can only have one aggregator. Error at column: ' + expr.position,
+                                message: 'Each step can only have one grouping expression. Error at column: ' + expr.position,
                                 stack: (new Error()).stack,
                                 position: expr.position
                             };
                         }
-                        result.aggregate = post_parse(expr.rhs);
+                        // object constructor - process each pair
+                        result.group = {
+                            lhs: expr.rhs.map(function (pair) {
+                                return [post_parse(pair[0]), post_parse(pair[1])];
+                            }),
+                            position: expr.position
+                        };
                         break;
                     default:
                         result = {type: expr.type, value: expr.value, position: expr.position};
@@ -689,6 +718,9 @@ var parser = function (source) {
                 // if so, need to mark the block as one that needs to create a new frame
                 break;
             case 'name':
+                result = [expr];
+                result.type = 'path';
+                break;
             case 'literal':
             case 'wildcard':
             case 'descendant':
@@ -743,12 +775,6 @@ var parser = function (source) {
         };
     }
     expr = post_parse(expr);
-
-    // a single name token is a single step location path
-    if (expr.type === 'name') {
-        expr = [expr];
-        expr.type = 'path';
-    }
 
     return expr;
 };
@@ -854,8 +880,8 @@ function evaluate(expr, input, environment) {
     if (expr.hasOwnProperty('predicate')) {
         result = applyPredicates(expr.predicate, result, environment);
     }
-    if (expr.hasOwnProperty('aggregate')) {
-        result = applyAggregate(expr.aggregate, result, environment);
+    if (expr.hasOwnProperty('group')) {
+        result = evaluateGroupExpression(expr.group, result, environment);
     }
 
     var exitCallback = environment.lookup('__evaluate_exit');
@@ -876,6 +902,7 @@ function evaluate(expr, input, environment) {
 function evaluatePath(expr, input, environment) {
     var result;
     var inputSequence;
+    var keepSingletonArray = false;
     // expr is an array of steps
     // if the first step is a variable reference ($...), including root reference ($$),
     //   then the path is absolute rather than relative
@@ -887,7 +914,11 @@ function evaluatePath(expr, input, environment) {
     }
 
     // evaluate each step in turn
-    expr.forEach(function (step) {
+    for(var ii = 0; ii < expr.length; ii++) {
+        var step = expr[ii];
+        if(step.keepArray === true) {
+            keepSingletonArray = true;
+        }
         var resultSequence = [];
         result = undefined;
         // if input is not an array, make it so
@@ -902,35 +933,36 @@ function evaluatePath(expr, input, environment) {
         if (expr.length > 1 && step.type === 'literal') {
             step.type = 'name';
         }
-        if (step.value === '{') {
-            if(typeof input !== 'undefined') {
-                result = evaluateGroupExpression(step, inputSequence, environment);
-            }
-        } else {
-            inputSequence.forEach(function (item) {
-                var res = evaluate(step, item, environment);
-                if (typeof res !== 'undefined') {
-                    if (Array.isArray(res)) {
-                        // is res an array - if so, flatten it into the parent array
-                        res.forEach(function (innerRes) {
-                            if (typeof innerRes !== 'undefined') {
-                                resultSequence.push(innerRes);
-                            }
-                        });
-                    } else {
-                        resultSequence.push(res);
-                    }
+        inputSequence.forEach(function (item) {
+            var res = evaluate(step, item, environment);
+            if (typeof res !== 'undefined') {
+                if (Array.isArray(res) && (step.value !== '[' || (step.lhs.length == 1 && step.lhs[0].value === '{'))) {
+                    // is res an array - if so, flatten it into the parent array
+                    res.forEach(function (innerRes) {
+                        if (typeof innerRes !== 'undefined') {
+                            resultSequence.push(innerRes);
+                        }
+                    });
+                } else {
+                    resultSequence.push(res);
                 }
-            });
-            if (resultSequence.length == 1) {
-                result = resultSequence[0];
-            } else if (resultSequence.length > 1) {
-                result = resultSequence;
             }
+        });
+        if (resultSequence.length == 1) {
+            if(keepSingletonArray) {
+                result = resultSequence;
+            } else {
+                result = resultSequence[0];
+            }
+        } else if (resultSequence.length > 1) {
+            result = resultSequence;
         }
 
+        if(typeof result === 'undefined') {
+            break;
+        }
         input = result;
-    });
+    }
     return result;
 }
 
@@ -1002,35 +1034,6 @@ function applyPredicates(predicates, input, environment) {
         }
         inputSequence = result;
     });
-    return result;
-}
-
-/**
- * Apply aggregate to input data
- * @param {Object} expr - JSONata expression
- * @param {Object} input - Input data to evaluate against
- * @param {Object} environment - Environment
- * @returns {{}} Result after applying aggregate
- */
-function applyAggregate(expr, input, environment) {
-    var result = {};
-    // this is effectively a 'reduce' HOF (fold left)
-    // if the input is a singleton, then just return this as the result
-    // otherwise iterate over the input array and aggregate the result
-    if (Array.isArray(input)) {
-        // create a new frame to limit the scope
-        var aggEnv = createFrame(environment);
-        // the variable $@ will hold the aggregated value, initialize this to the first array item
-        aggEnv.bind('_', input[0]);
-        // loop over the remainder of the array
-        for (var index = 1; index < input.length; index++) {
-            var reduce = evaluate(expr, input[index], aggEnv);
-            aggEnv.bind('_', reduce);
-        }
-        result = aggEnv.lookup('_');
-    } else {
-        result = input;
-    }
     return result;
 }
 
@@ -1111,11 +1114,10 @@ function evaluateUnary(expr, input, environment) {
             expr.lhs.forEach(function (item) {
                 var value = evaluate(item, input, environment);
                 if (typeof value !== 'undefined') {
-                    if (item.value === '..') {
-                        // array generated by the range operator - merge into results
-                        result = functionAppend(result, value);
-                    } else {
+                    if(item.value === '[') {
                         result.push(value);
+                    } else {
+                        result = functionAppend(result, value);
                     }
                 }
             });
@@ -1548,7 +1550,7 @@ function evaluateBindExpression(expr, input, environment) {
             stack: (new Error()).stack,
             position: expr.position,
             token: expr.value,
-            value: expr.lhs.value
+            value: expr.lhs.type === 'path' ? expr.lhs[0].value : expr.lhs.value
         };
     }
     environment.bind(expr.lhs.value, value);
@@ -1634,13 +1636,13 @@ function evaluateFunction(expr, input, environment) {
     // evaluate it generically first, then check that it is a function.  Throw error if not.
     var proc = evaluate(expr.procedure, input, environment);
 
-    if (typeof proc === 'undefined' && expr.procedure.type === 'name' && environment.lookup(expr.procedure.value)) {
+    if (typeof proc === 'undefined' && expr.procedure.type === 'path' && environment.lookup(expr.procedure[0].value)) {
         // help the user out here if they simply forgot the leading $
         throw {
-            message: 'Attempted to invoke a non-function at column ' + expr.position + '. Did you mean \'$' + expr.procedure.value + '\'?',
+            message: 'Attempted to invoke a non-function at column ' + expr.position + '. Did you mean \'$' + expr.procedure[0].value + '\'?',
             stack: (new Error()).stack,
             position: expr.position,
-            token: expr.procedure.value
+            token: expr.procedure[0].value
         };
     }
     // apply the procedure
@@ -1662,7 +1664,7 @@ function evaluateFunction(expr, input, environment) {
         // add the position field to the error
         err.position = expr.position;
         // and the function identifier
-        err.token = expr.procedure.value;
+        err.token = expr.procedure.type === 'path' ? expr.procedure[0].value : expr.procedure.value;
         throw err;
     }
     return result;
@@ -1734,13 +1736,13 @@ function evaluatePartialApplication(expr, input, environment) {
     });
     // lookup the procedure
     var proc = evaluate(expr.procedure, input, environment);
-    if (typeof proc === 'undefined' && expr.procedure.type === 'name' && environment.lookup(expr.procedure.value)) {
+    if (typeof proc === 'undefined' && expr.procedure.type === 'path' && environment.lookup(expr.procedure[0].value)) {
         // help the user out here if they simply forgot the leading $
         throw {
-            message: 'Attempted to partially apply a non-function at column ' + expr.position + '. Did you mean \'$' + expr.procedure.value + '\'?',
+            message: 'Attempted to partially apply a non-function at column ' + expr.position + '. Did you mean \'$' + expr.procedure[0].value + '\'?',
             stack: (new Error()).stack,
             position: expr.position,
-            token: expr.procedure.value
+            token: expr.procedure[0].value
         };
     }
     if (proc && proc.lambda) {
@@ -1752,7 +1754,7 @@ function evaluatePartialApplication(expr, input, environment) {
             message: 'Attempted to partially apply a non-function at column ' + expr.position,
             stack: (new Error()).stack,
             position: expr.position,
-            token: expr.procedure.value
+            token: expr.procedure.type === 'path' ? expr.procedure[0].value : expr.procedure.value
         };
     }
     return result;

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -1611,6 +1611,15 @@ describe('Evaluator - desendant operator', function () {
         });
     });
 
+    describe('**', function () {
+        it('should return result object', function () {
+            var expr = jsonata('**');
+            var result = expr.evaluate();
+            var expected = undefined;
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
 });
 
 describe('Evaluator - string concat', function () {
@@ -1876,6 +1885,85 @@ describe('Evaluator - array flattening', function () {
             var expr = jsonata('nest0.nest1.nest2.nest3');
             var result = expr.evaluate(testdata3);
             var expected = [1, 2, 3, 4, 5, 6, 7, 8];
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+});
+
+describe('Evaluator - keep singleton arrays', function () {
+
+    describe('Phone[type="mobile"].number', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone[type="mobile"].number');
+            var result = expr.evaluate(testdata4);
+            var expected = "077 7700 1234";
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Phone[type="mobile"][].number', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone[type="mobile"][].number');
+            var result = expr.evaluate(testdata4);
+            var expected = ["077 7700 1234"];
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Phone[][type="mobile"].number', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone[][type="mobile"].number');
+            var result = expr.evaluate(testdata4);
+            var expected = ["077 7700 1234"];
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Phone[type="office"][].number', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone[type="office"][].number');
+            var result = expr.evaluate(testdata4);
+            var expected = [
+                "01962 001234",
+                "01962 001235"
+            ];
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Phone{type: number}', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone{type: number}');
+            var result = expr.evaluate(testdata4);
+            var expected = {
+                "home": "0203 544 1234",
+                "office": [
+                    "01962 001234",
+                    "01962 001235"
+                ],
+                "mobile": "077 7700 1234"
+            };
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Phone{type: number[]}', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Phone{type: number[]}');
+            var result = expr.evaluate(testdata4);
+            var expected = {
+                "home": [
+                    "0203 544 1234"
+                ],
+                "office": [
+                    "01962 001234",
+                    "01962 001235"
+                ],
+                "mobile": [
+                    "077 7700 1234"
+                ]
+            };
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
@@ -5219,7 +5307,7 @@ describe('Evaluator - errors', function () {
                 var expr = jsonata('2(blah)');
                 expr.evaluate();
             }).to.throw()
-                .to.deep.contain({position: 2})
+                .to.deep.contain({position: 2, token: 2})
                 .to.have.property('message').to.match(/Attempted to invoke a non-function/);
         });
     });
@@ -5230,8 +5318,19 @@ describe('Evaluator - errors', function () {
                 var expr = jsonata('2()');
                 expr.evaluate();
             }).to.throw()
-                .to.deep.contain({position: 2})
+                .to.deep.contain({position: 2, token: 2})
                 .to.have.property('message').to.match(/Attempted to invoke a non-function/);
+        });
+    });
+
+    describe('3(?)', function () {
+        it('should throw error', function () {
+            expect(function () {
+                var expr = jsonata('3(?)');
+                expr.evaluate();
+            }).to.throw()
+              .to.deep.contain({position:2, token: 3})
+              .to.have.property('message').to.match(/Attempted to partially apply a non-function/);
         });
     });
 
@@ -5262,6 +5361,17 @@ describe('Evaluator - errors', function () {
             }).to.throw()
                 .to.deep.contain({position: 3, token: ':=', value: 'x'})
                 .to.have.property('message').to.match(/Left hand side of := must be a variable name/);
+        });
+    });
+
+    describe('2:=1', function () {
+        it('should throw error', function () {
+            expect(function () {
+                var expr = jsonata('2:=1');
+                expr.evaluate();
+            }).to.throw()
+              .to.deep.contain({position: 3, token: ':=', value: 2})
+              .to.have.property('message').to.match(/Left hand side of := must be a variable name/);
         });
     });
 
@@ -5298,25 +5408,25 @@ describe('Evaluator - errors', function () {
         });
     });
 
-    describe('[1,2,3]{$+$_}[true]', function () {
+    describe('[1,2,3]{"num": $}[true]', function () {
         it('should throw error', function () {
             expect(function () {
-                var expr = jsonata('[1,2,3]{$+$_}[true]');
+                var expr = jsonata('[1,2,3]{"num": $}[true]');
                 expr.evaluate();
             }).to.throw()
-                .to.deep.contain({position: 14})
-                .to.have.property('message').to.match(/A predicate cannot follow an aggregate in a step/);
+                .to.deep.contain({position: 18})
+                .to.have.property('message').to.match(/A predicate cannot follow a grouping expression in a step/);
         });
     });
 
-    describe('[1,2,3]{$+$_}{$+$_}', function () {
+    describe('[1,2,3]{"num": $}{"num": $}', function () {
         it('should throw error', function () {
             expect(function () {
-                var expr = jsonata('[1,2,3]{$+$_}{$+$_}');
+                var expr = jsonata('[1,2,3]{"num": $}{"num": $}');
                 expr.evaluate();
             }).to.throw()
-                .to.deep.contain({position: 14})
-                .to.have.property('message').to.match(/Each step can only have one aggregator/);
+                .to.deep.contain({position: 18})
+                .to.have.property('message').to.match(/Each step can only have one grouping expression/);
         });
     });
 
@@ -5395,7 +5505,7 @@ describe('Evaluator - array constructor', function () {
         it('should return result object', function () {
             var expr = jsonata('["foo.bar", foo.bar, ["foo.baz", foo.blah.baz]]');
             var result = expr.evaluate(testdata1);
-            var expected = ["foo.bar", 42, ["foo.baz", [{"fud": "hello"}, {"fud": "world"}]]];
+            var expected = ["foo.bar", 42, ["foo.baz", {"fud": "hello"}, {"fud": "world"}]];
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
@@ -5431,7 +5541,7 @@ describe('Evaluator - array constructor', function () {
         it('should return result object', function () {
             var expr = jsonata('foo.blah.baz.[fud, fud]');
             var result = expr.evaluate(testdata1);
-            var expected = ["hello", "hello", "world", "world"];
+            var expected = [["hello","hello"],["world","world"]];
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
@@ -5440,7 +5550,7 @@ describe('Evaluator - array constructor', function () {
         it('should return result object', function () {
             var expr = jsonata('foo.blah.baz.[[fud, fud]]');
             var result = expr.evaluate(testdata1);
-            var expected = [["hello", "hello"], ["world", "world"]];
+            var expected = [[["hello","hello"]],[["world","world"]]];
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
@@ -5671,20 +5781,38 @@ describe('Evaluator - object constructor', function () {
         });
     });
 
-    describe('Account.Order.{OrderID: Product."Product Name"}', function () {
+    describe('Account.Order{OrderID: Product."Product Name"}', function () {
         it('should return result object', function () {
-            var expr = jsonata('Account.Order.{OrderID: Product."Product Name"}');
+            var expr = jsonata('Account.Order{OrderID: Product."Product Name"}');
             var result = expr.evaluate(testdata2);
             var expected = {"order103": ["Bowler Hat", "Trilby hat"], "order104": ["Bowler Hat", "Cloak"]};
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
 
-    describe('Account.Order.[{OrderID: Product."Product Name"}]', function () {
+    describe('Account.Order.{OrderID: Product."Product Name"}', function () {
         it('should return result object', function () {
-            var expr = jsonata('Account.Order.[{OrderID: Product."Product Name"}]');
+            var expr = jsonata('Account.Order.{OrderID: Product."Product Name"}');
             var result = expr.evaluate(testdata2);
             var expected = [{"order103": ["Bowler Hat", "Trilby hat"]}, {"order104": ["Bowler Hat", "Cloak"]}];
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Account.Order.Product{$string(ProductID): Price}', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Account.Order.Product{$string(ProductID): Price}');
+            var result = expr.evaluate(testdata2);
+            var expected = {"345664": 107.99, "858236": 21.67, "858383": [34.45, 34.45]};
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Account.Order.Product{$string(ProductID): (Price)[0]}', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Account.Order.Product{$string(ProductID): (Price)[0]}');
+            var result = expr.evaluate(testdata2);
+            var expected = {"345664": 107.99, "858236": 21.67, "858383": 34.45};
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
@@ -5693,26 +5821,19 @@ describe('Evaluator - object constructor', function () {
         it('should return result object', function () {
             var expr = jsonata('Account.Order.Product.{$string(ProductID): Price}');
             var result = expr.evaluate(testdata2);
-            var expected = {"345664": 107.99, "858236": 21.67, "858383": [34.45, 34.45]};
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('Account.Order.Product.{$string(ProductID): Price[0]}', function () {
-        it('should return result object', function () {
-            var expr = jsonata('Account.Order.Product.{$string(ProductID): Price[0]}');
-            var result = expr.evaluate(testdata2);
-            var expected = {"345664": 107.99, "858236": 21.67, "858383": 34.45};
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('Account.Order.Product.[{$string(ProductID): Price}]', function () {
-        it('should return result object', function () {
-            var expr = jsonata('Account.Order.Product.[{$string(ProductID): Price}]');
-            var result = expr.evaluate(testdata2);
             var expected = [{"858383": 34.45}, {"858236": 21.67}, {"858383": 34.45}, {"345664": 107.99}];
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('Account.Order.Product{ProductID: "Product Name"}', function () {
+        it('should throw error', function () {
+            var expr = jsonata('Account.Order.Product{ProductID: "Product Name"}');
+            expect(function () {
+                expr.evaluate(testdata2);
+            }).to.throw()
+                .to.deep.contain({position: 22, value: 858383})
+                .to.have.property('message').to.match(/Key in object structure must evaluate to a string/);
         });
     });
 
@@ -5727,14 +5848,12 @@ describe('Evaluator - object constructor', function () {
         });
     });
 
-    describe('Account.Order.Product.[{ProductID: "Product Name"}]', function () {
-        it('should throw error', function () {
-            var expr = jsonata('Account.Order.Product.[{ProductID: "Product Name"}]');
-            expect(function () {
-                expr.evaluate(testdata2);
-            }).to.throw()
-                .to.deep.contain({position: 24, value: 858383})
-                .to.have.property('message').to.match(/Key in object structure must evaluate to a string/);
+    describe('Account.Order{OrderID: $sum(Product.(Price*Quantity))}', function () {
+        it('should return result object', function () {
+            var expr = jsonata('Account.Order{OrderID: $sum(Product.(Price*Quantity))}');
+            var result = expr.evaluate(testdata2);
+            var expected = {"order103": 90.57000000000001, "order104": 245.79000000000002};
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
 
@@ -5742,23 +5861,14 @@ describe('Evaluator - object constructor', function () {
         it('should return result object', function () {
             var expr = jsonata('Account.Order.{OrderID: $sum(Product.(Price*Quantity))}');
             var result = expr.evaluate(testdata2);
-            var expected = {"order103": 90.57000000000001, "order104": 245.79000000000002};
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('Account.Order.[{OrderID: $sum(Product.(Price*Quantity))}]', function () {
-        it('should return result object', function () {
-            var expr = jsonata('Account.Order.[{OrderID: $sum(Product.(Price*Quantity))}]');
-            var result = expr.evaluate(testdata2);
             var expected = [{"order103": 90.57000000000001}, {"order104": 245.79000000000002}];
             assert.equal(JSON.stringify(result), JSON.stringify(expected));
         });
     });
 
-    describe('Account.Order.Product.{$."Product Name": Price, $."Product Name": Price}', function () {
+    describe('Account.Order.Product{$."Product Name": Price, $."Product Name": Price}', function () {
         it('should return result object', function () {
-            var expr = jsonata('Account.Order.Product.{$."Product Name": Price, $."Product Name": Price}');
+            var expr = jsonata('Account.Order.Product{$."Product Name": Price, $."Product Name": Price}');
             var result = expr.evaluate(testdata2);
             var expected = {
                 "Bowler Hat": [
@@ -5782,7 +5892,7 @@ describe('Evaluator - object constructor', function () {
 
     describe('Object & array transform', function () {
         it('should return result object', function () {
-            var expr = jsonata('Account.Order.{' +
+            var expr = jsonata('Account.Order{' +
               '  OrderID: {' +
               '    "TotalPrice":$sum(Product.(Price * Quantity)),' +
               '    "Items": Product."Product Name"' +
@@ -5882,9 +5992,9 @@ describe('Evaluator - object constructor', function () {
         });
     });
 
-    describe('Phone.{type:number{$ & ", " & $_}, "phone":number}', function () {
+    describe('Phone{type: $join(number, ", "), "phone":number}', function () {
         it('should return result object', function () {
-            var expr = jsonata('Phone.{type:number{$ & ", " & $_}, "phone":number}');
+            var expr = jsonata('Phone{type: $join(number, ", "), "phone":number}');
             var result = expr.evaluate(testdata4);
             var expected = {
                 "home": "0203 544 1234",
@@ -5894,67 +6004,10 @@ describe('Evaluator - object constructor', function () {
                     "01962 001235",
                     "077 7700 1234"
                 ],
-                "office": "01962 001235, 01962 001234",
+                "office": "01962 001234, 01962 001235",
                 "mobile": "077 7700 1234"
             };
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-});
-
-describe('Evaluator - aggregator', function () {
-    describe('Account.Order.Product.Price{$+$_}', function () {
-        it('should return result object', function () {
-            var expr = jsonata('Account.Order.Product.Price{$+$_}');
-            var result = expr.evaluate(testdata2);
-            var expected = 198.56;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('(Account.Order.Product.Price){$+$_}', function () {
-        it('should return result object', function () {
-            var expr = jsonata('(Account.Order.Product.Price){$+$_}');
-            var result = expr.evaluate(testdata2);
-            var expected = 198.56;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('(Account.Order.Product.Price)[0]{$+$_} ', function () {
-        it('should return result object', function () {
-            var expr = jsonata('(Account.Order.Product.Price)[0]{$+$_} ');
-            var result = expr.evaluate(testdata2);
-            var expected = 34.45;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('Account.Order.Product.(Price*Quantity){$+$_} ', function () {
-        it('should return result object', function () {
-            var expr = jsonata('Account.Order.Product.(Price*Quantity){$+$_} ');
-            var result = expr.evaluate(testdata2);
-            var expected = 336.36;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('[1,2,3]{$+$_}', function () {
-        it('should return result object', function () {
-            var expr = jsonata('[1,2,3]{$+$_}');
-            var result = expr.evaluate(null);
-            var expected = 6;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
-        });
-    });
-
-    describe('1{$+$_}', function () {
-        it('should return result object', function () {
-            var expr = jsonata('1{$+$_}');
-            var result = expr.evaluate(null);
-            var expected = 1;
-            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+            expect(result).to.be.deep.equal(expected);
         });
     });
 
@@ -6673,7 +6726,7 @@ describe('Evaluator - Closures', function () {
 
                 'Account.(' +
                 '  $AccName := function() { $."Account Name" };' +
-                '  Order[OrderID = "order104"].Product.{' +
+                '  Order[OrderID = "order104"].Product{' +
                 '    "Account": $AccName(),' +
                 '    "SKU-" & $string(ProductID): $."Product Name"' +
                 '  } ' +
@@ -7390,15 +7443,15 @@ describe('#evaluate', function () {
                     .to.have.property('message').to.match(/Attempted to invoke a non-function/);
             });
 
-            it('unsupported function, e.g. this.authentication()', function () {
-                var expr = 'this.authentication(Salutation)';
+            it('unsupported function, e.g. Employment.authentication()', function () {
+                var expr = 'Employment.authentication(Salutation)';
 
                 var evaluate = function () {
                     jsonata(expr).evaluate(person);
                 };
 
                 expect(evaluate).to.throw()
-                    .to.deep.contain({position: 20, token: 'authentication'})
+                    .to.deep.contain({position: 26, token: 'authentication'})
                     .to.have.property('message').to.match(/Attempted to invoke a non-function/);
             });
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -185,7 +185,7 @@ is addressing a single value in the structure and it makes sense to return just 
 In the last two expressions, however, it is not immediately obvious how many values will be matched, and it is
 not helpful if the host language has to process the results in different ways depending on what gets returned.
 
-If this is a concern, then the expression can be modified to make it return an array even if obly a single value is matched.
+If this is a concern, then the expression can be modified to make it return an array even if only a single value is matched.
 This is done by adding empty square brackets `[]` to a step within the location path.  The examples above can be re-written
 to always return an array as follows:
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -133,7 +133,6 @@ the document as follows:
 | `$[0].ref[0]` | `1` | returns element on first position of the internal array
 | `$.ref` | `[ 1, 2, 3, 4 ]` | Despite the structure of the nested array, the resultant selection<br>is flattened into a single flat array.  The original nested structure<br>of the input arrays is lost. See [Array constructors](#array-constructors) for how to<br>maintain the original structure in the results.
 
-
 ###Complex selection
 
 ####Wildcards
@@ -165,6 +164,37 @@ Expression | Output | Comments|
 | `Phone[type='mobile']` | `{ "type": "mobile",  "number": "077 7700 1234" }` | Select the `Phone` items that have a `type` field that equals `"mobile"`.
 | `Phone[type='mobile'].number` | `"077 7700 1234"` | Select the mobile phone number
 | `Phone[type='office'].number` | `[ "01962 001234",  "01962 001235" ]` | Select the office phone numbers - there are two of them!
+
+####Singleton array and value equivalence
+Within a JSONata expression or subexpression, any value (which is not itself an array) and an array
+containing just that value are deemed to be equivalent.  This allows the language to be composable
+such that location paths that extract a single value from and object and location paths
+that extract multiple values from arrays can both be used as inputs to other expressions
+without needing to use different syntax for the two forms.
+
+Consider the following examples:
+
+* `Address.City` returns the single value `"Winchester"`
+* `Phone[0].number` matches a single value, and returns that value `"0203 544 1234"`
+* `Phone[type='home'].number` likewise matches the single value `"0203 544 1234"`
+* `Phone[type='office'].number` matches two values, so returns an array `[ "01962 001234",  "01962 001235" ]`
+
+When processing the return value of a JSONata expression, it might be desirable to have the results in a consistent
+format regardless of how many values were matched.  In the first two expressions above, it is clear that each expression
+is addressing a single value in the structure and it makes sense to return just that value. 
+In the last two expressions, however, it is not immediately obvious how many values will be matched, and it is
+not helpful if the host language has to process the results in different ways depending on what gets returned.
+
+If this is a concern, then the expression can be modified to make it return an array even if obly a single value is matched.
+This is done by adding empty square brackets `[]` to a step within the location path.  The examples above can be re-written
+to always return an array as follows:
+
+* `Address[].City` returns `[ "Winchester"] `
+* `Phone[0][].number` returns `[ "0203 544 1234" ]`
+* `Phone[][type='home'].number` returns `[ "0203 544 1234" ]`
+* `Phone[type='office'].number[]` returns `[ "01962 001234",  "01962 001235" ]`
+
+Note that the `[]` can be placed either side of the predicates and on any step in the path expression
 
 ###Combining values
 
@@ -217,6 +247,7 @@ Supported operators:
 - `<=` less than or equal
 - `>` greater than
 - `>=` greater than or equal
+- `in` value is contained in an array
 
 
 _Examples_
@@ -229,6 +260,7 @@ Expression | Output | Comments
 | `Numbers[1] <= Numbers[5]` | true |Less than or equal|
 | `Numbers[2] > Numbers[4]` | false |Greater than|
 | `Numbers[2] >= Numbers[4]` | false |Greater than or equal|
+| `"01962 001234" in Phone.number` | true | Value is contained in|
 
 ####Boolean expressions
 Used to combine Boolean results, often to support more sophisticated predicate expressions.
@@ -279,16 +311,16 @@ pairs separated by commas, with each key and value separated by a colon: `{key1:
 keys and values can either be literals or can be expressions. The key must either be a string or an expression that
 evaluates to a string.
 
-When an object constructor follows a location path that selects multiple values, the object constructor will create
+When an object constructor follows an expression that selects multiple values, the object constructor will create
 a single object that contains a key/value pair for each of those context values.  If an array of objects is required
-(one for each context value), then the object constructor should be combined with the array constructor.
+(one for each context value), then the object constructor should immediately follow the dot '.' operator.
 
 Examples:
 
 Expression | Output | Comments|
 | ---------- | ------ |----|
-| `Phone.{type: number}` | `{ "home": "0203 544 1234", "office": "01962 001235", "mobile": "077 7700 1234" }` | One of the `office` numbers was lost because it had a duplicate key
-| `Phone.[{type: number}]` | `[ { "home": "0203 544 1234" }, { "office": "01962 001234" }, { "office": "01962 001235" }, { "mobile": "077 7700 1234"  } ]` | Produces an array of objects
+| `Phone{type: number}` | `{ "home": "0203 544 1234", "office": "01962 001235", "mobile": "077 7700 1234" }` | One of the `office` numbers was lost because it had a duplicate key
+| `Phone.{type: number}` | `[ { "home": "0203 544 1234" }, { "office": "01962 001234" }, { "office": "01962 001235" }, { "mobile": "077 7700 1234"  } ]` | Produces an array of objects
 
 ####JSON literals
 The array and object constructors use the standard JSON syntax for JSON arrays and JSON objects.  In addition to this


### PR DESCRIPTION
User feedback suggests that the mechanism for creating 'grouped' objects versus arrays of objects is confusing.  Currently creating a grouped or merged object is done using the following syntax:
`location.path.{key: value}`
and the syntax for creating arrays of objects is:
`location.path.[{key: value}]`

The confusion arises because the `.` operator is really a 'map' higher order function, so the expectation is that each value in the array on the LHS of `.` should produce a value in a result array without the need for any array syntax.  The function that processes this `.` operator has special case handling for .{} to enable this grouping, and that is probably a Bad Thing. 

So I have removed this 'special case' code and now `location.path.{key: value}` behaves like `location.path.[{key: value}]` used to.  The group-by (merge) capability can now be achieved using the following:
`location.path{key: value}`
There is no `.` operator before the object constructor.

Other feedback related to how the results of expressions are getting returned.  Currently, if multiple values are matched by an expression, they are returned in a flattened array.  If a single value is matched, it is returned directly (not in an array).  This can be nuisance for the host language to process if it is not known whether an expression is going to match a single or multiple values.  The host code would have to query the type first before iterating over the result (or not).  Worse still is if the offending expression is embedded in, say, an object constructor expression such as:
`Phone{type:number}`
In this case we could end up with a result object like this:
```
{
  "home": "0203 544 1234",
  "office": [
    "01962 001234",
    "01962 001235"
  ],
  "mobile": "077 7700 1234"
}
```
 whereby some of the object values are arrays and some are not.

To fix this, I have introduced some new syntax `[]` which, if appended to a step, will force the output to always be an array.  This can be mixed with predicates without any problem. E.g.:


`Phone{type:number[]}`
produces
```
{
  "home": [
    "0203 544 1234"
  ],
  "office": [
    "01962 001234",
    "01962 001235"
  ],
  "mobile": [
    "077 7700 1234"
  ]
}
```

`Phone[type='home'][].number`
produces
`[ "0203 544 1234" ]`