### PR TITLE
fix variable scope when overridden by undefined

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -2728,8 +2728,10 @@ var jsonata = (function() {
                 bindings[name] = value;
             },
             lookup: function (name) {
-                var value = bindings[name];
-                if (typeof value === 'undefined' && enclosingEnvironment) {
+                var value;
+                if(bindings.hasOwnProperty(name)) {
+                    value = bindings[name];
+                } else if (enclosingEnvironment) {
                     value = enclosingEnvironment.lookup(name);
                 }
                 return value;

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -2070,6 +2070,29 @@ describe('Evaluator - variables', function () {
 });
 
 
+describe('Evaluator - variable scope', function () {
+
+    describe('( $foo := "defined"; ( $foo := nothing ); $foo )', function () {
+        it('should return result object', function () {
+            var expr = jsonata('( $foo := "defined"; ( $foo := nothing ); $foo )');
+            var result = expr.evaluate();
+            var expected = "defined";
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+    describe('( $foo := "defined"; ( $foo := nothing; $foo ) )', function () {
+        it('should return result object', function () {
+            var expr = jsonata('( $foo := "defined"; ( $foo := nothing; $foo ) )');
+            var result = expr.evaluate();
+            var expected = undefined;
+            assert.equal(JSON.stringify(result), JSON.stringify(expected));
+        });
+    });
+
+});
+
+
 describe('Evaluator - functions: sum', function () {
 
     describe('$sum(Account.Order.Product.(Price * Quantity))', function () {


### PR DESCRIPTION
The following expression binds a variable $foo, then overrides it in a nested scope.  It should return undefined because `bar` matches nothing in the input.  However, it incorrectly returns 'foo'.
```
(
  $foo := 'foo';
  (
    $foo := bar;
    $foo
  )
)
```

This incorrect behaviour only occurs when overriding with `undefined` because of an error in the lookup code. 
