### PR TITLE
Add .npmignore to remove unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*
+!jsonata.js
+!LICENSE
+!package.json
+!README.md


### PR DESCRIPTION
Adding a `.npmignore` file so that the package published to npm contains only the files needed when installed. That is, `jsonata.js`, `package.json`, the license and the readme.