### PR TITLE
Base64 encode (btoa) and decode (atob) functions

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -3120,6 +3120,41 @@ var jsonata = (function() {
         return result;
     }
 
+    /**
+     * Base64 encode a string
+     * @param {String} str - string
+     * @returns {String} Base 64 encoding of the binary data
+     */
+    function functionBase64encode(str) {
+        // undefined inputs always return undefined
+        if(typeof str === 'undefined') {
+            return undefined;
+        }
+        // Use btoa in a browser, or Buffer in Node.js
+        // eslint-disable-next-line
+        var btoa = btoa || function(str) {
+            return new Buffer(str, 'binary').toString('base64');
+        };
+        return btoa(str);
+    }
+
+    /**
+     * Base64 decode a string
+     * @param {String} str - string
+     * @returns {String} Base 64 encoding of the binary data
+     */
+    function functionBase64decode(str) {
+        // undefined inputs always return undefined
+        if(typeof str === 'undefined') {
+            return undefined;
+        }
+        // Use btoa in a browser, or Buffer in Node.js
+        // eslint-disable-next-line
+        var atob = atob || function(str) {
+            return new Buffer(str, 'base64').toString('binary');
+        };
+        return atob(str);
+    }
 
     /**
      * Split a string into an array of substrings
@@ -3933,6 +3968,8 @@ var jsonata = (function() {
     staticFrame.bind('each', defineFunction(functionEach, '<o-f:a>'));
     staticFrame.bind('sort', defineFunction(functionSort, '<af?:a>'));
     staticFrame.bind('shuffle', defineFunction(functionShuffle, '<a:a>'));
+    staticFrame.bind('base64encode', defineFunction(functionBase64encode, '<s-:s>'));
+    staticFrame.bind('base64decode', defineFunction(functionBase64decode, '<s-:s>'));
 
     /**
      * Error codes
@@ -4105,4 +4142,3 @@ var jsonata = (function() {
 if(typeof module !== 'undefined') {
     module.exports = jsonata;
 }
-

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -8323,6 +8323,45 @@ describe('Regex', function () {
         });
 
     });
+
+    describe('Functions - $base64encode', function () {
+        describe('$base64encode("hello:world")', function () {
+            it('should return result object', function () {
+                var expr = jsonata('$base64encode("hello:world")');
+                var result = expr.evaluate();
+                var expected = "aGVsbG86d29ybGQ=";
+                expect(result).to.deep.equal(expected);
+            });
+        });
+        describe('$base64encode(undefined)', function () {
+            it('should return result object', function () {
+                var expr = jsonata('$base64encode()');
+                var result = expr.evaluate();
+                var expected = undefined;
+                expect(result).to.deep.equal(expected);
+            });
+        });
+    });
+
+    describe('Functions - $base64decode', function () {
+        describe('$base64decode("aGVsbG86d29ybGQ=")', function () {
+            it('should return result object', function () {
+                var expr = jsonata('$base64decode("aGVsbG86d29ybGQ=")');
+                var result = expr.evaluate();
+                var expected = "hello:world";
+                expect(result).to.deep.equal(expected);
+            });
+        });
+        describe('$base64decode(undefined)', function () {
+            it('should return result object', function () {
+                var expr = jsonata('$base64decode()');
+                var result = expr.evaluate();
+                var expected = undefined;
+                expect(result).to.deep.equal(expected);
+            });
+        });
+    });
+
 });
 
 describe('Evaluator - function application operator', function () {
@@ -9684,4 +9723,3 @@ describe('end to end scenarios', function () {
         expect(pe.evaluate(data2)).to.deep.equal('boo');
     });
 });
-


### PR DESCRIPTION
These simple string<->base64 functions are helpful when constructing basic auth headers.
The code in this pull request provides trivial implementations that should work in both a browser (where btoa and atob) functions are available, and in a Node.js runtime where these are available via Buffer.

A further extension would be to support binary<->base64, but I'm not sure of:
- The right representation of binary in a JSONata structure (or if this is defined yet)
- How to distinguish the expected return value, when decoding a string. Should that be a different function name?