### PR TITLE
Correctly handle null values when executed with a callback

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -1374,7 +1374,7 @@ var jsonata = (function() {
         }
 
         if(environment.lookup('__jsonata_async') &&
-          (typeof result === 'undefined' || typeof result.then !== 'function')) {
+          (typeof result === 'undefined' || result === null || typeof result.then !== 'function')) {
             result = Promise.resolve(result);
         }
         result = yield result;

--- a/test/async-function.js
+++ b/test/async-function.js
@@ -83,3 +83,25 @@ describe('Invoke JSONata with callback - errors', function() {
     });
 });
 
+describe('Invoke JSONata with callback - return values', function() {
+    it('should handle an undefined value', function() {
+        var data = { value: undefined };
+        var expr = jsonata('value');
+        return expect(jsonataPromise(expr, data)).to.eventually.equal(undefined);
+    });
+    it('should handle a null value', function() {
+        var data = { value: null };
+        var expr = jsonata('value');
+        return expect(jsonataPromise(expr, data)).to.eventually.equal(null);
+    });
+    it('should handle a value', function() {
+        var data = { value: 'hello' };
+        var expr = jsonata('value');
+        return expect(jsonataPromise(expr, data)).to.eventually.equal('hello');
+    });
+    it('should handle a promise', function() {
+        var data = { value: Promise.resolve('hello') };
+        var expr = jsonata('value');
+        return expect(jsonataPromise(expr, data)).to.eventually.equal('hello');
+    });
+});


### PR DESCRIPTION
The following error occurs when jsonata is invoked with a callback and an expression that returns a `null` value:

```
TypeError: Cannot read property 'then' of null
      at evaluate (jsonata.js:1377:58)
      at next (native)
      at evaluateStep (jsonata.js:1476:31)
      at next (native)
      at evaluatePath (jsonata.js:1429:38)
      at next (native)
      at evaluate (jsonata.js:1323:34)
      at next (native)
      at Object.evaluate (jsonata.js:4117:33)
      at test/async-function.js:20:14
      at jsonataPromise (test/async-function.js:19:12)
      at Context.<anonymous> (test/async-function.js:95:23)
```