### PR TITLE
Include the Babel polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
   "plugins": [
     ["transform-runtime", {
       "helpers": false,
-      "polyfill": false,
+      "polyfill": true,
       "regenerator": true,
       "moduleName": "babel-runtime"
     }]


### PR DESCRIPTION
IE 11 and PhantomJS do not support ES6 features such as `Symbol` and it looks like I didn't configure `.babelrc` to pull in the polyfill for this feature.

Unfortunately this bloats `jsonata-es5.js` even further, from 212kB to 277kB. `jsonata-es5.min.js` now increases from 53kB to 85kB. So this is just a temporary instant fix for now, until I figure out how to pull in only the `Symbol` polyfill by itself and nothing else.