### PR TITLE
Adopt node 8 in Travis, drop node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
+- '8'
 - '7'
 - '6'
-- '5'
-- '4.4'
+- '4'
 after_success:
 - npm run coveralls
 deploy:


### PR DESCRIPTION
According to the node.js LTS schedule v8.x is now the current release and will become the LTS release in October, so it would be good to start testing JSONata against it now. Equally, v5.x is neither a current release or an LTS (v4.x is in maintenance, v6.x is active) and likely has little usage so it can be dropped from the list.

Also switching to `'4'` from `'4.4'` to pick up latest v4.x release instead of v4.4.x.