### PR TITLE
Write out token value, not internal type

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -685,7 +685,7 @@ var jsonata = (function() {
                 var err = {
                     code: code,
                     position: node.position,
-                    token: node.id,
+                    token: node.value,
                     value: id
                 };
                 return handleError(err);

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -5873,6 +5873,15 @@ describe('Evaluator - errors', function () {
         });
     });
 
+    describe('$replace("foo", "o, "rr")', function () {
+        it('should throw error', function () {
+            expect(function () {
+                jsonata('$replace("foo", "o, "rr")');
+            }).to.throw()
+                .to.deep.contain({position: 24, code: 'S0202', token: 'rr"', value: ')'});
+        });
+    });
+
     describe('[1!2]', function () {
         it('should throw error', function () {
             expect(function () {

--- a/test/parser-recovery.js
+++ b/test/parser-recovery.js
@@ -170,7 +170,7 @@ describe('Invoke parser with incomplete expression', function() {
                 {
                     "code": "S0202",
                     "position": 16,
-                    "token": "(literal)",
+                    "token": "0",
                     "value": "]",
                     "remaining": [
                         {


### PR DESCRIPTION
Fixes https://github.com/jsonata-js/jsonata/issues/73

The `S0202` message currently reports the internal token type, rather than the token value.  For some tokens that's ok (because they are the same), but for `name` and `literal` tokens at least, it's better for the user to see the values that they typed, rather than the confusing `(name)` and `(literal)`.