### PR TITLE
Support ES6 Class in path 

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -1797,7 +1797,7 @@ var jsonata = (function() {
                     result.push(res);
                 }
             }
-        } else if (input !== null && typeof input === 'object') {
+        } else if (input !== null && ( typeof input === 'object' || isClass(input))) {
             result = input[expr.value];
         }
         result = normalizeSequence(result);

--- a/jsonata.js
+++ b/jsonata.js
@@ -4305,6 +4305,10 @@ var jsonata = (function() {
             }
         };
     }
+    function isClass(func) {
+        return typeof func === 'function' 
+            && /^class\s/.test(Function.prototype.toString.call(func));
+    }
 
     jsonata.parser = parser; // TODO remove this in a future release - use ast() instead
 

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -10046,3 +10046,14 @@ describe('end to end scenarios', function () {
         expect(pe.evaluate(data2)).to.deep.equal('boo');
     });
 });
+describe('class in path', function () {
+    it('use class in path', function () {
+        class TestClass {
+            static get testValue(){
+                return "testValue";
+            }
+        }
+        var expected = 'testValue';
+        expect(jsonata('class.testValue').evaluate({class:TestClass})).to.deep.equal(expected);
+    });
+});


### PR DESCRIPTION
This small change supports the use of ES6 classes in jsonata path. Currently it can only support objects but the class is a special type of function.