### PR TITLE
Add new functions to convert between ISO 8601 timestamps and milliseconds since epoch

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -4075,7 +4075,7 @@ var jsonata = (function() {
      * @param {Number} millis - milliseconds since the epoch to be converted
      * @returns {String} - an ISO 8601 formatted timestamp
      */
-    function functionToDateTime(millis) {
+    function functionFromMillis(millis) {
         // undefined inputs always return undefined
         if(typeof millis === 'undefined') {
             return undefined;
@@ -4154,7 +4154,7 @@ var jsonata = (function() {
     staticFrame.bind('base64encode', defineFunction(functionBase64encode, '<s-:s>'));
     staticFrame.bind('base64decode', defineFunction(functionBase64decode, '<s-:s>'));
     staticFrame.bind('toMillis', defineFunction(functionToMillis, '<s-:n>'));
-    staticFrame.bind('toDateTime', defineFunction(functionToDateTime, '<n-:s>'));
+    staticFrame.bind('fromMillis', defineFunction(functionFromMillis, '<n-:s>'));
 
     /**
      * Error codes

--- a/jsonata.js
+++ b/jsonata.js
@@ -4919,7 +4919,7 @@ var jsonata = (function() {
         "D3091": "The fractional part of the sub-picture must not contain an instance of the 'optional digit character' that is followed by a member of the 'decimal digit family'",
         "D3092": "A sub-picture that contains a 'percent' or 'per-mille' character must not contain a character treated as an 'exponent-separator'",
         "D3093": "The exponent part of the sub-picture must comprise only of one or more characters that are members of the 'decimal digit family'",
-        "D3100": "The radix of the formatBase function must be between 2 and 36.  It was given {{value}}"
+        "D3100": "The radix of the formatBase function must be between 2 and 36.  It was given {{value}}",
         "D3110": "The argument of the toMillis function must be an ISO 8601 formatted timestamp. Given {{value}}"
     };
 

--- a/jsonata.js
+++ b/jsonata.js
@@ -4044,6 +4044,46 @@ var jsonata = (function() {
         return result;
     }
 
+    // Regular expression to match an ISO 8601 formatted timestamp
+    var iso8601regex = new RegExp('^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z)$');
+
+    /**
+     * Converts an ISO 8601 timestamp to milliseconds since the epoch
+     *
+     * @param {string} timestamp - the ISO 8601 timestamp to be converted
+     * @returns {Number} - milliseconds since the epoch
+     */
+    function functionToMillis(timestamp) {
+        // undefined inputs always return undefined
+        if(typeof timestamp === 'undefined') {
+            return undefined;
+        }
+
+        if(!iso8601regex.test(timestamp)) {
+            throw {
+                stack: (new Error()).stack,
+                code: "D3110",
+                value: timestamp
+            };
+        }
+
+        return Date.parse(timestamp);
+    }
+
+    /**
+     * Converts milliseconds since the epoch to an ISO 8601 timestamp
+     * @param {Number} millis - milliseconds since the epoch to be converted
+     * @returns {String} - an ISO 8601 formatted timestamp
+     */
+    function functionToDateTime(millis) {
+        // undefined inputs always return undefined
+        if(typeof millis === 'undefined') {
+            return undefined;
+        }
+
+        return new Date(millis).toISOString();
+    }
+
     /**
      * Create frame
      * @param {Object} enclosingEnvironment - Enclosing environment
@@ -4113,6 +4153,8 @@ var jsonata = (function() {
     staticFrame.bind('shuffle', defineFunction(functionShuffle, '<a:a>'));
     staticFrame.bind('base64encode', defineFunction(functionBase64encode, '<s-:s>'));
     staticFrame.bind('base64decode', defineFunction(functionBase64decode, '<s-:s>'));
+    staticFrame.bind('toMillis', defineFunction(functionToMillis, '<s-:n>'));
+    staticFrame.bind('toDateTime', defineFunction(functionToDateTime, '<n-:s>'));
 
     /**
      * Error codes
@@ -4171,7 +4213,8 @@ var jsonata = (function() {
         "D3050": "First argument of reduce function must be a function with two arguments",
         "D3060": "The sqrt function cannot be applied to a negative number: {{value}}",
         "D3061": "The power function has resulted in a value that cannot be represented as a JSON number: base={{value}}, exponent={{exp}}",
-        "D3070": "The single argument form of the sort function can only be applied to an array of strings or an array of numbers.  Use the second argument to specify a comparison function"
+        "D3070": "The single argument form of the sort function can only be applied to an array of strings or an array of numbers.  Use the second argument to specify a comparison function",
+        "D3110": "The argument of the toMillis function must be an ISO 8601 formatted timestamp. Given {{value}}"
     };
 
     /**

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -6310,8 +6310,7 @@ describe('Evaluator - functions: clone', function () {
         });
     });
 });
-          
-          
+
 describe('Evaluator - errors', function () {
 
     describe('"s" - 1', function () {

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -5838,29 +5838,29 @@ describe('Evaluator - function: toMillis', function () {
 
 });
 
-describe('Evaluator - function: toDateTime', function () {
+describe('Evaluator - function: fromMillis', function () {
 
-    describe('toDateTime() returns an ISO 8601 timestamp when given 1 millisecond since the epoch', function () {
+    describe('fromMillis() returns an ISO 8601 timestamp when given 1 millisecond since the epoch', function () {
         it('should return result object', function () {
-            var expr = jsonata('$toDateTime(1)');
+            var expr = jsonata('$fromMillis(1)');
             var result = expr.evaluate(testdata2);
             var expected = '1970-01-01T00:00:00.001Z';
             expect(expected).to.deep.equal(result);
         });
     });
 
-    describe('toDateTime() returns an ISO 8601 timestamp when given many milliseconds since the epoch ', function () {
+    describe('fromMillis() returns an ISO 8601 timestamp when given many milliseconds since the epoch ', function () {
         it('should return result object', function () {
-            var expr = jsonata('$toDateTime(1509380732935)');
+            var expr = jsonata('$fromMillis(1509380732935)');
             var result = expr.evaluate(testdata2);
             var expected = "2017-10-30T16:25:32.935Z";
             expect(expected).to.deep.equal(result);
         });
     });
 
-    describe('toDateTime() returns undefined when given undefined', function () {
+    describe('fromMillis() returns undefined when given undefined', function () {
         it('should return result object', function () {
-            var expr = jsonata('$toDateTime(foo)');
+            var expr = jsonata('$fromMillis(foo)');
             var result = expr.evaluate(testdata2);
             var expected = undefined;
             expect(expected).to.deep.equal(result);

--- a/test/jsonata-test.js
+++ b/test/jsonata-test.js
@@ -5797,6 +5797,78 @@ describe('Evaluator - function: millis', function () {
 
 });
 
+describe('Evaluator - function: toMillis', function () {
+
+    describe('toMillis() returns 1 millisecond since the epoch when provided with an ISO 8601 timestamp', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toMillis("1970-01-01T00:00:00.001Z")');
+            var result = expr.evaluate(testdata2);
+            var expected = 1;
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+    describe('toMillis() returns many milliseconds since the epoch when provided with an ISO 8601 timestamp', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toMillis("2017-10-30T16:25:32.935Z")');
+            var result = expr.evaluate(testdata2);
+            var expected = 1509380732935;
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+    describe('toMillis() returns undefined when given undefined', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toMillis(foo)');
+            var result = expr.evaluate(testdata2);
+            var expected = undefined;
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+    describe('when toMillis() is not given an ISO 8601 timestamp', function () {
+        it('should return an error', function () {
+            var expr = jsonata('$toMillis("foo")');
+            expect(function () {
+                expr.evaluate(testdata2);
+            }).to.throw()
+                .to.deep.contain({position: 10, code: 'D3110', value: 'foo'});
+        });
+    });
+
+});
+
+describe('Evaluator - function: toDateTime', function () {
+
+    describe('toDateTime() returns an ISO 8601 timestamp when given 1 millisecond since the epoch', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toDateTime(1)');
+            var result = expr.evaluate(testdata2);
+            var expected = '1970-01-01T00:00:00.001Z';
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+    describe('toDateTime() returns an ISO 8601 timestamp when given many milliseconds since the epoch ', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toDateTime(1509380732935)');
+            var result = expr.evaluate(testdata2);
+            var expected = "2017-10-30T16:25:32.935Z";
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+    describe('toDateTime() returns undefined when given undefined', function () {
+        it('should return result object', function () {
+            var expr = jsonata('$toDateTime(foo)');
+            var result = expr.evaluate(testdata2);
+            var expected = undefined;
+            expect(expected).to.deep.equal(result);
+        });
+    });
+
+});
+
 describe('Evaluator - errors', function () {
 
     describe('"s" - 1', function () {


### PR DESCRIPTION
As suggested in #55, there is a requirement to convert between ISO 8601 formatted timestamps (like those generated by the `$now()` function) and milliseconds since epoch (as generated by `$millis()`).

This PR adds two new functions, `toMillis(<timestamp_string>)` and `fromMillis(<number>)`, to do this.

Pulling this into the `1.4` branch for now so that it can be rolled up with the other changes and new functions for that release.