### PR TITLE
Start testing against node.js 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+- '9'
 - '8'
-- '7'
 - '6'
 - '4'
 after_success:


### PR DESCRIPTION
Now that node.js 8 is LTS and 9 is latest the testing should be expanded to include the new version. Version 7 has dropped out of support, so removing to save Travis cycles.

This could be done against `master`, but including on this branch so it doesn't fall behind again unnecessarily.