### PR TITLE
Establish some (common) VS code settings (for those using it)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    // To avoid different format settings from
+    // triggering cosmetic changes.
+    "editor.formatOnSave": false,
+}


### PR DESCRIPTION
This just initiates some project level settings for VSCode.  In this case, I just wanted to turn off `formatOnSave` because it might cause unnecessarily cosmetic changes if everybody formats the code according to different style guidelines.

Of course, this should not impact people who are not using VSCode.