### PR TITLE
Adding TypeScript definitions directly in package

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for jsonata 1.4
+// Project: https://github.com/jsonata-js/jsonata
+// Definitions by: Nick <https://github.com/nick121212> and Michael M. Tiller <https://github.com/xogeny>
+
+declare function jsonata(str: string): jsonata.Expression;
+declare namespace jsonata {
+  interface Expression {
+    evaluate(input: any, bindings?: { [name: string]: any }, callback?: (err: Error, resp: any) => void): any;
+    assign(name: string, value: any): void;
+    registerFunction(name: string, f: Function, signature?: string): void;
+  }
+}
+
+export = jsonata;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.1",
   "description": "JSON query and transformation language",
   "main": "jsonata.js",
+  "typings": "jsonata.d.ts",
   "homepage": "http://jsonata.org/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This eliminates the need to install `@types/jsonata` and corrects a few issues in those type definitions as well.  Specifically, the callback arguments for `evaluate` were missing, I've added
them in.  Also, the signature for the `assign` function was wrong (it only allowed functions to be
bound the variables), that is also fixed.  Finally, the `registerFunction` method on compiled
expressions was completely missing, I've added that as well.

I've tested this by removing `@types/jsonata` as a dependency from my TypeScript project
and then installing this version of `jsonata` from my local file system.  Not only are the type
definitions correctly located by the TypeScript compilers, but the errors I had associated with
some of the problems with the previous type definitions are also gone.