### PR TITLE
Missing default case

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -465,6 +465,7 @@ var jsonata = (function() {
                         }
                         break;
                     case 'undefined':
+                    default:
                         // any value can be undefined, but should be allowed to match
                         symbol = 'm'; // m for missing
                 }
@@ -516,7 +517,7 @@ var jsonata = (function() {
                         var arg = args[argIndex];
                         var match = isValid[index + 1];
                         if(match === '') {
-                            if (param.context) {
+                            if (param.context && param.contextRegex) {
                                 // substitute context value for missing arg
                                 // first check that the context value is the right type
                                 var contextType = getSymbol(context);


### PR DESCRIPTION
I noticed that `getSymbol` could fall through without returning any value.  The expected return type is a string, but without this default case, it can return `undefined`.

Also, added an extra guard to an if statement to ensure that `contextRegex` is really defined.  I see that they are (currently) defined together.  But the TypeScript compiler flagged this as a potential issue.  Seems reasonable to put this guard in place just in case at some future the "defined together" behavior changes.