### PR TITLE
Establish a way to run only tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "node ./node_modules/istanbul/lib/cli.js cover --report cobertura --report html ./node_modules/mocha/bin/_mocha -- \"test/**/*.js\"",
+    "mocha": "node ./node_modules/istanbul/lib/cli.js cover --report cobertura --report html ./node_modules/mocha/bin/_mocha -- \"test/**/*.js\"",
+    "test": "npm run mocha",
     "posttest": "npm run check-coverage && npm run minify && npm run babel && npm run browserify && npm run minify-es5",
     "check-coverage": "istanbul check-coverage -statement 100 -branch 100 -function 100 -line 100",
     "minify": "uglifyjs jsonata.js -o jsonata.min.js --compress --mangle",


### PR DESCRIPTION
This slight change to `package.json` creates a new script called `mocha`.

Invoking `npm run mocha` allows **only** tests to be run (no lint, no coverage, etc).
This doe not change the behavior of `npm test` at all, it simply adds a new script
that can be used to invoke only tests.

Signed-off-by: Michael M. Tiller <michael.tiller@gmail.com>