### PR TITLE
Remove leftover comment

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -4653,7 +4653,6 @@ var jsonata = (function() {
     }
 
     // Regular expression to match an ISO 8601 formatted timestamp
-    // Uses https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ but removes the "week number" format not supported by Date.parse
     var iso8601regex = new RegExp('^\\d{4}(-[01]\\d)*(-[0-3]\\d)*(T[0-2]\\d:[0-5]\\d:[0-5]\\d)*(\\.\\d+)?([+-][0-2]\\d:?[0-5]\\d|Z)?$');
 
     /**


### PR DESCRIPTION
I left a comment in https://github.com/jsonata-js/jsonata/pull/141 when I was originally using a regex string I'd sourced elsewhere, but due to the issues I ran into I ended up crafting my own string; removing the comment as it would be more confusing that the regex no longer matches the one on the referenced URL.