### PR TITLE
Fix tail-call optimiser for predicated function invocations

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -1090,7 +1090,7 @@ var jsonata = (function() {
         // This enables tail-recursive functions to be written without growing the stack
         var tail_call_optimize = function(expr) {
             var result;
-            if(expr.type === 'function') {
+            if(expr.type === 'function' && !expr.predicate) {
                 var thunk = {type: 'lambda', thunk: true, arguments: [], position: expr.position};
                 thunk.body = expr;
                 result = thunk;

--- a/test/test-suite/groups/lambdas/case012.json
+++ b/test/test-suite/groups/lambdas/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "( $median := λ($x){$sort($x)[$count($x)/2]};  $median([5,4,3,2,1,6,7,8,1]) )",
+    "dataset": null,
+    "bindings": {},
+    "result": 4
+}


### PR DESCRIPTION
If the body a lambda function ends with a function call, it gets replaced by a thunk so as not to grow the stack at runtime (allowing tail recursion).  If the function call is followed by a predicate, then it is not a tail-call, and should not be replaced.  The check for this is missing and has been added by this PR.
