### PR TITLE
move validation of LHS of := from evaluator to parser

### DIFF
--- a/test/test-suite/groups/errors/case018.json
+++ b/test/test-suite/groups/errors/case018.json
@@ -2,5 +2,5 @@
     "expr": "2:=1",
     "dataset": null,
     "bindings": {},
-    "code": "D2005"
+    "code": "S0212"
 }

--- a/test/test-suite/groups/variables/case012.json
+++ b/test/test-suite/groups/variables/case012.json
@@ -1,5 +1,5 @@
 {
-    "expr": "x:=1",
+    "expr": "($a := [1,2]; $a[1]:=3; $a)",
     "dataset": null,
     "bindings": {},
     "code": "S0212"


### PR DESCRIPTION
The left hand side of the binding operator `:=` must be a variable.  This PR moves the validation of this rule from the evaluator (which throws a dynamic error) to the parser (throws a syntax error).  This is also more robust since it is checking against the token type rather than a node in the AST.

Resolves #148 which was ignoring the predicate attached to the variable in the AST.