### PR TITLE
test signature validation of tail recursive function

### DIFF
--- a/test/test-suite/groups/tail-recursion/case008.json
+++ b/test/test-suite/groups/tail-recursion/case008.json
@@ -1,0 +1,8 @@
+{
+    "expr": "($f := function($s, $x)<an:s> { $x > 0 ? $f([$s, $s], $x-1) : $s};  $f('a', 2)  )",
+    "dataset": null,
+    "timelimit": 1000,
+    "depth": 500,
+    "bindings": {},
+    "result": ["a","a","a","a"]
+}

--- a/test/test-suite/groups/tail-recursion/case009.json
+++ b/test/test-suite/groups/tail-recursion/case009.json
@@ -1,0 +1,8 @@
+{
+    "expr": "($f := function($s, $x)<sn:s> { $x > 0 ? $f([$s, $s], $x-1) : $s};  $f('a', 2)  )",
+    "dataset": null,
+    "timelimit": 1000,
+    "depth": 500,
+    "bindings": {},
+    "code": "T0410"
+}


### PR DESCRIPTION
Issue #137 raised the question (I believe) as to whether lambda function signatures survive the tail-call optimization process, and hence get validated at runtime.  This PR contains a test case that demonstrates that it does.  A tail recursive function has been written such that its initial invocation conforms to the signature, but inside the function it invokes itself with an invalid argument.  The validation fails as expected.  A variant of this test has also been added which passes validation throughout.