### PR TITLE
handle undefined inputs in $formatNumber

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -3570,6 +3570,11 @@ var jsonata = (function() {
      * @returns {String} The formatted string
      */
     function functionFormatNumber(value, picture, options) {
+        // undefined inputs always return undefined
+        if(typeof value === 'undefined') {
+            return undefined;
+        }
+
         var defaults = {
             "decimal-separator": ".",
             "grouping-separator": ",",

--- a/test/test-suite/groups/function-formatNumber/case036.json
+++ b/test/test-suite/groups/function-formatNumber/case036.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$formatNumber(foo, '#0.00')",
+    "dataset": null,
+    "bindings": {},
+    "undefinedResult": true
+}


### PR DESCRIPTION
Add usual `undefined` handling to `$formatNumber` function

Resolves #165 