### PR TITLE
add function $charCode(str,int)

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -4748,6 +4748,22 @@ var jsonata = (function() {
     }
 
     /**
+     * Get the character code of a character in a string
+     * @param {String} str - the string
+     * @param {Number} [index] - index inside the string. If no index is given, this defaults to 0
+     * @returns {Number} - an integer between 0 and 65535 representing the UTF-16 code unit at the given index
+     */
+    function functionCharCode(str, index) {
+        if(typeof str !== 'string') {
+            return undefined;
+        }
+        if(typeof index !== 'number') {
+            index = 0;
+        }
+        return str.charCodeAt(index) ;
+    }
+
+    /**
      * Create frame
      * @param {Object} enclosingEnvironment - Enclosing environment
      * @returns {{bind: bind, lookup: lookup}} Created frame
@@ -4822,6 +4838,7 @@ var jsonata = (function() {
     staticFrame.bind('toMillis', defineFunction(functionToMillis, '<s-:n>'));
     staticFrame.bind('fromMillis', defineFunction(functionFromMillis, '<n-:s>'));
     staticFrame.bind('clone', defineFunction(functionClone, '<(oa)-:o>'));
+    staticFrame.bind('charCode', defineFunction(functionCharCode, '<s-n?:n>'));
 
     /**
      * Error codes

--- a/test/test-suite/groups/function-charCode/case000.json
+++ b/test/test-suite/groups/function-charCode/case000.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$charCode(\"H\")",
+    "dataset": null,
+    "bindings": {},
+    "result": 72
+}

--- a/test/test-suite/groups/function-charCode/case001.json
+++ b/test/test-suite/groups/function-charCode/case001.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$charCode(\"Hello World\", 3)",
+    "dataset": null,
+    "bindings": {},
+    "result": 108
+}

--- a/test/test-suite/groups/function-charCode/case002.json
+++ b/test/test-suite/groups/function-charCode/case002.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$charCode(\"a\", 0)",
+    "dataset": null,
+    "bindings": {},
+    "result": 97
+}

--- a/test/test-suite/groups/function-charCode/case003.json
+++ b/test/test-suite/groups/function-charCode/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$charCode(undefined, 0)",
+    "dataset": null,
+    "bindings": {},
+    "undefinedResult": true
+}


### PR DESCRIPTION
This is one of the two functions I suggested in #192 which makes JavaScripts str.charCodeAt() function available in JSONATA.