### PR TITLE
add support for custom matcher functions

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -2397,6 +2397,25 @@ var jsonata = (function() {
     }
 
     /**
+     * Evaluate the matcher function against the str arg
+     *
+     * @param {*} matcher - matching function (native or lambda)
+     * @param {string} str - the string to match against
+     * @returns {object} - structure that represents the match(es)
+     */
+    function* evaluateMatcher(matcher, str) {
+        var result = yield * apply(matcher, [str]);
+        if(result && !(typeof result.start === 'number' || result.end === 'number' || Array.isArray(result.groups) || isFunction(result.next))) {
+            // the matcher function didn't return the correct structure
+            throw {
+                code: "T1010",
+                stack: (new Error()).stack,
+            };
+        }
+        return result;
+    }
+
+    /**
      * Evaluate variable against input data
      * @param {Object} expr - JSONata expression
      * @param {Object} input - Input data to evaluate against
@@ -3249,7 +3268,7 @@ var jsonata = (function() {
      * @param {String} token - substring or regex to find
      * @returns {Boolean} - true if str contains token
      */
-    function functionContains(str, token) {
+    function* functionContains(str, token) {
         // undefined inputs always return undefined
         if(typeof str === 'undefined') {
             return undefined;
@@ -3260,7 +3279,7 @@ var jsonata = (function() {
         if(typeof token === 'string') {
             result = (str.indexOf(token) !== -1);
         } else {
-            var matches = token(str);
+            var matches = yield * evaluateMatcher(token, str);
             result = (typeof matches !== 'undefined');
         }
 
@@ -3274,7 +3293,7 @@ var jsonata = (function() {
      * @param {Integer} [limit] - max number of matches to return
      * @returns {Array} The array of match objects
      */
-    function functionMatch(str, regex, limit) {
+    function* functionMatch(str, regex, limit) {
         // undefined inputs always return undefined
         if(typeof str === 'undefined') {
             return undefined;
@@ -3294,7 +3313,7 @@ var jsonata = (function() {
 
         if(typeof limit === 'undefined' || limit > 0) {
             var count = 0;
-            var matches = regex(str);
+            var matches = yield * evaluateMatcher(regex, str);
             if (typeof matches !== 'undefined') {
                 while (typeof matches !== 'undefined' && (typeof limit === 'undefined' || count < limit)) {
                     result.push({
@@ -3302,7 +3321,7 @@ var jsonata = (function() {
                         index: matches.start,
                         groups: matches.groups
                     });
-                    matches = matches.next();
+                    matches = yield * evaluateMatcher(matches.next);
                     count++;
                 }
             }
@@ -3415,7 +3434,7 @@ var jsonata = (function() {
                 }
                 result += str.substring(position);
             } else {
-                var matches = pattern(str);
+                var matches = yield * evaluateMatcher(pattern, str);
                 if (typeof matches !== 'undefined') {
                     while (typeof matches !== 'undefined' && (typeof limit === 'undefined' || count < limit)) {
                         result += str.substring(position, matches.start);
@@ -3433,7 +3452,7 @@ var jsonata = (function() {
                         }
                         position = matches.start + matches.match.length;
                         count++;
-                        matches = matches.next();
+                        matches = yield * evaluateMatcher(matches.next);
                     }
                     result += str.substring(position);
                 } else {
@@ -3499,7 +3518,7 @@ var jsonata = (function() {
      * @param {Integer} [limit] - max number of substrings
      * @returns {Array} The array of string
      */
-    function functionSplit(str, separator, limit) {
+    function* functionSplit(str, separator, limit) {
         // undefined inputs always return undefined
         if(typeof str === 'undefined') {
             return undefined;
@@ -3522,13 +3541,13 @@ var jsonata = (function() {
                 result = str.split(separator, limit);
             } else {
                 var count = 0;
-                var matches = separator(str);
+                var matches = yield * evaluateMatcher(separator, str);
                 if (typeof matches !== 'undefined') {
                     var start = 0;
                     while (typeof matches !== 'undefined' && (typeof limit === 'undefined' || count < limit)) {
                         result.push(str.substring(start, matches.start));
                         start = matches.end;
-                        matches = matches.next();
+                        matches = yield * evaluateMatcher(matches.next);
                         count++;
                     }
                     if(typeof limit === 'undefined' || count < limit) {
@@ -4834,6 +4853,7 @@ var jsonata = (function() {
         "T1007": "Attempted to partially apply a non-function. Did you mean ${{{token}}}?",
         "T1008": "Attempted to partially apply a non-function",
         "D1009": "Multiple key definitions evaluate to same key: {{value}}",
+        "T1010": "The matcher function argument passed to function {{token}} does not return the correct object structure",
         "T2001": "The left side of the {{token}} operator must evaluate to a number",
         "T2002": "The right side of the {{token}} operator must evaluate to a number",
         "T2003": "The left side of the range operator (..) must evaluate to an integer",

--- a/test/run-test-suite-async.js
+++ b/test/run-test-suite-async.js
@@ -58,7 +58,7 @@ function jsonataPromise(expr, data, bindings) {
 describe("JSONata Test Suite - async mode", () => {
     // Iterate over all groups of tests
     groups.forEach(group => {
-        let casenames = fs.readdirSync(path.join(__dirname, "test-suite", "groups", group));
+        let casenames = fs.readdirSync(path.join(__dirname, "test-suite", "groups", group)).filter((name) => name.endsWith(".json"));
         // Read JSON file containing all cases for this group
         let cases = casenames.map((name) => readJSON(path.join("test-suite", "groups", group), name));
         describe("Group: " + group, () => {
@@ -66,6 +66,11 @@ describe("JSONata Test Suite - async mode", () => {
             for (let i = 0; i < cases.length; i++) {
                 // Extract the current test case of interest
                 let testcase = cases[i];
+
+                // if the testcase references and external jsonata file, read it in
+                if(testcase['expr-file']) {
+                    testcase.expr = fs.readFileSync(path.join(__dirname, "test-suite", "groups", group, testcase['expr-file'])).toString();
+                }
 
                 // Create a test based on the data in this testcase
                 it(casenames[i]+": "+testcase.expr, function() {

--- a/test/run-test-suite-async.js
+++ b/test/run-test-suite-async.js
@@ -67,7 +67,7 @@ describe("JSONata Test Suite - async mode", () => {
                 // Extract the current test case of interest
                 let testcase = cases[i];
 
-                // if the testcase references and external jsonata file, read it in
+                // if the testcase references an external jsonata file, read it in
                 if(testcase['expr-file']) {
                     testcase.expr = fs.readFileSync(path.join(__dirname, "test-suite", "groups", group, testcase['expr-file'])).toString();
                 }

--- a/test/run-test-suite.js
+++ b/test/run-test-suite.js
@@ -40,7 +40,7 @@ datasetnames.forEach((name) => {
 describe("JSONata Test Suite", () => {
     // Iterate over all groups of tests
     groups.forEach(group => {
-        let casenames = fs.readdirSync(path.join(__dirname, "test-suite", "groups", group));
+        let casenames = fs.readdirSync(path.join(__dirname, "test-suite", "groups", group)).filter((name) => name.endsWith(".json"));
         // Read JSON file containing all cases for this group
         let cases = casenames.map((name) => readJSON(path.join("test-suite", "groups", group), name));
         describe("Group: " + group, () => {
@@ -48,6 +48,11 @@ describe("JSONata Test Suite", () => {
             for (let i = 0; i < cases.length; i++) {
                 // Extract the current test case of interest
                 let testcase = cases[i];
+
+                // if the testcase references and external jsonata file, read it in
+                if(testcase['expr-file']) {
+                    testcase.expr = fs.readFileSync(path.join(__dirname, "test-suite", "groups", group, testcase['expr-file'])).toString();
+                }
 
                 // Create a test based on the data in this testcase
                 it(casenames[i]+": "+testcase.expr, function() {

--- a/test/run-test-suite.js
+++ b/test/run-test-suite.js
@@ -49,7 +49,7 @@ describe("JSONata Test Suite", () => {
                 // Extract the current test case of interest
                 let testcase = cases[i];
 
-                // if the testcase references and external jsonata file, read it in
+                // if the testcase references an external jsonata file, read it in
                 if(testcase['expr-file']) {
                     testcase.expr = fs.readFileSync(path.join(__dirname, "test-suite", "groups", group, testcase['expr-file'])).toString();
                 }

--- a/test/test-suite/groups/matchers/case000.json
+++ b/test/test-suite/groups/matchers/case000.json
@@ -1,0 +1,32 @@
+{
+  "expr-file": "case000.jsonata",
+  "dataset": null,
+  "bindings": {},
+  "result": [
+    {
+      "match": "a",
+      "index": 0,
+      "groups": []
+    },
+    {
+      "match": "a",
+      "index": 3,
+      "groups": []
+    },
+    {
+      "match": "a",
+      "index": 5,
+      "groups": []
+    },
+    {
+      "match": "a",
+      "index": 7,
+      "groups": []
+    },
+    {
+      "match": "a",
+      "index": 10,
+      "groups": []
+    }
+  ]
+}

--- a/test/test-suite/groups/matchers/case000.jsonata
+++ b/test/test-suite/groups/matchers/case000.jsonata
@@ -1,0 +1,18 @@
+(
+    $generateMatcher := function($ch) {
+      $match := function($str, $offset) {(
+        $before := $substringBefore($str, $ch);
+        $start := $length($before) + ($exists($offset) ? $offset : 0);
+        $end := $start + $length($ch);
+        $before != $str and $length($ch) > 0 ? {
+          'match': $ch,
+          'start': $start,
+          'end': $end,
+          'groups': [],
+          'next': function() {$match($substringAfter($str, $ch), $end)}
+        }
+      )}
+    };
+
+    $match("abracadabra", $generateMatcher('a'))
+)

--- a/test/test-suite/groups/matchers/case001.json
+++ b/test/test-suite/groups/matchers/case001.json
@@ -1,0 +1,6 @@
+{
+  "expr": "$split('some text', $uppercase)",
+  "dataset": null,
+  "bindings": {},
+  "code": "T1010"
+}


### PR DESCRIPTION
The four functions `$match`, `$contains`, `$split` and `$replace` can take a regex argument.  The regex syntax `/.../` is in fact just some syntactic sugar for a higher-order function that generates a 'matcher' function.  This matcher function, when invoked on a string, will return a well defined structure (which I haven't documented yet :blush:) which describes the match(es).  It was designed so that these four functions could work with any pluggable matching scheme, not just the built-in regex, provided the matcher returned the correct object structure.  That's the theory, but I never got round to testing it.  This PR fixes that.  Custom matchers can now be implemented in jsonata as lambdas or as external javascript functions.

Resolves #213 