### PR TITLE
$substring should handle negative start position and length

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -3087,9 +3087,16 @@ var jsonata = (function() {
             return undefined;
         }
 
+        if(str.length + start < 0) {
+            start = 0;
+        }
+
         var strArray = Array.from(str);
         if(typeof length !== 'undefined') {
-            var end = start >= 0 ? start + length : strArray.length - start + length;
+            if(length <= 0) {
+                return '';
+            }
+            var end = start >= 0 ? start + length : strArray.length + start + length;
             return strArray.slice(start, end).join('');
         }
 

--- a/jsonata.js
+++ b/jsonata.js
@@ -3087,16 +3087,18 @@ var jsonata = (function() {
             return undefined;
         }
 
-        if(str.length + start < 0) {
+        var strArray = Array.from(str);
+        var strLength = strArray.length;
+
+        if(strLength + start < 0) {
             start = 0;
         }
 
-        var strArray = Array.from(str);
         if(typeof length !== 'undefined') {
             if(length <= 0) {
                 return '';
             }
-            var end = start >= 0 ? start + length : strArray.length + start + length;
+            var end = start >= 0 ? start + length : strLength + start + length;
             return strArray.slice(start, end).join('');
         }
 

--- a/test/test-suite/groups/function-substring/case008.json
+++ b/test/test-suite/groups/function-substring/case008.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -5, 5)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "world"
+}

--- a/test/test-suite/groups/function-substring/case009.json
+++ b/test/test-suite/groups/function-substring/case009.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -5, 4)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "worl"
+}

--- a/test/test-suite/groups/function-substring/case010.json
+++ b/test/test-suite/groups/function-substring/case010.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -5, 1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "w"
+}

--- a/test/test-suite/groups/function-substring/case011.json
+++ b/test/test-suite/groups/function-substring/case011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -5, 0)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": ""
+}

--- a/test/test-suite/groups/function-substring/case012.json
+++ b/test/test-suite/groups/function-substring/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -5, -1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": ""
+}

--- a/test/test-suite/groups/function-substring/case013.json
+++ b/test/test-suite/groups/function-substring/case013.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", 0, -6)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": ""
+}

--- a/test/test-suite/groups/function-substring/case014.json
+++ b/test/test-suite/groups/function-substring/case014.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"hello world\", -100, 3)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "hel"
+}

--- a/test/test-suite/groups/function-substring/case015.json
+++ b/test/test-suite/groups/function-substring/case015.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"😂😁😀\", -2, 1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "😁"
+}

--- a/test/test-suite/groups/function-substring/case016.json
+++ b/test/test-suite/groups/function-substring/case016.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"😂😁😀\", -3, 1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "😂"
+}

--- a/test/test-suite/groups/function-substring/case017.json
+++ b/test/test-suite/groups/function-substring/case017.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"😂😁😀\", -4, 1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "😂"
+}

--- a/test/test-suite/groups/function-substring/case018.json
+++ b/test/test-suite/groups/function-substring/case018.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$substring(\"😂😁😀\", -5, 1)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": "😂"
+}


### PR DESCRIPTION
The fix for #156 introduced a regression into the `$substring` function when dealing with negative values of start parameter (count from end of string).  This was caused by a miscalculation of the end position.  Also added checks to prevent start position and length from going below zero, in line with the previous behaviour.

Resolves #204 