### PR TITLE
third argument of apply() should not be environment

### DIFF
--- a/jsonata.js
+++ b/jsonata.js
@@ -2397,7 +2397,7 @@ var jsonata = (function() {
      * @returns {object} - structure that represents the match(es)
      */
     function* evaluateMatcher(matcher, str) {
-        var result = yield * apply(matcher, [str]);
+        var result = yield * apply(matcher, [str], null);
         if(result && !(typeof result.start === 'number' || result.end === 'number' || Array.isArray(result.groups) || isFunction(result.next))) {
             // the matcher function didn't return the correct structure
             throw {
@@ -2532,7 +2532,7 @@ var jsonata = (function() {
                     position: expr.position
                 };
             }
-            var result = yield * apply(cloneFunction, [obj], environment);
+            var result = yield * apply(cloneFunction, [obj], null);
             var matches = yield * evaluate(expr.pattern, result, environment);
             if(typeof matches !== 'undefined') {
                 if(!Array.isArray(matches)) {
@@ -2626,9 +2626,9 @@ var jsonata = (function() {
                 // this is function chaining (func1 ~> func2)
                 // λ($f, $g) { λ($x){ $g($f($x)) } }
                 var chain = yield * evaluate(chainAST, null, environment);
-                result = yield * apply(chain, [lhs, func], environment);
+                result = yield * apply(chain, [lhs, func], null);
             } else {
-                result = yield * apply(func, [lhs], environment);
+                result = yield * apply(func, [lhs], null);
             }
 
         }


### PR DESCRIPTION
As discussed in issue #164, the third argument of the internal `apply()` function should never be passed the `environment` structure.  In cases where this occurs, I've replaced it with `null`.  This has no effect of any of the tests.

Resolves #164 
