### PR TITLE
Get Travis to test against node 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '9'
+- '10'
 - '8'
 - '6'
 - '4'


### PR DESCRIPTION
As of the end of April node `10.x` as replaced `9.x` as the latest release.

As `9.x` is a non-LTS release it drops off support really quickly, so we no longer need to test against it, but we should be testing against `10.x` which becomes the LTS in October.