### PR TITLE
fix sort syntax when applied as first step in path to an input array

### DIFF
--- a/test/parser-recovery.js
+++ b/test/parser-recovery.js
@@ -291,6 +291,7 @@ describe('Invoke parser with incomplete expression', function() {
                 "type": "sort",
                 "value": "^",
                 "position": 36,
+                "consarray": true,
                 "lhs": {
                     "type": "path",
                     "steps": [

--- a/test/test-suite/groups/sorting/case014.json
+++ b/test/test-suite/groups/sorting/case014.json
@@ -1,0 +1,14 @@
+{
+    "expr": "$^(age).name",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": [
+        "Sally",
+        "Bill",
+        "Jim"
+    ]
+}

--- a/test/test-suite/groups/sorting/case015.json
+++ b/test/test-suite/groups/sorting/case015.json
@@ -1,0 +1,14 @@
+{
+    "expr": "($^(age)).name",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": [
+        "Sally",
+        "Bill",
+        "Jim"
+    ]
+}

--- a/test/test-suite/groups/sorting/case016.json
+++ b/test/test-suite/groups/sorting/case016.json
@@ -1,0 +1,10 @@
+{
+    "expr": "$^(age)[0].name",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": "Sally"
+}

--- a/test/test-suite/groups/sorting/case017.json
+++ b/test/test-suite/groups/sorting/case017.json
@@ -1,0 +1,10 @@
+{
+    "expr": "($^(age))[0].name",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": "Sally"
+}

--- a/test/test-suite/groups/sorting/case018.json
+++ b/test/test-suite/groups/sorting/case018.json
@@ -1,0 +1,10 @@
+{
+    "expr": "($^(age)[0]).name",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": "Sally"
+}

--- a/test/test-suite/groups/sorting/case019.json
+++ b/test/test-suite/groups/sorting/case019.json
@@ -1,0 +1,10 @@
+{
+    "expr": "$[0]^(age)",
+    "data": [
+        {"name": "Bill", "age": 35},
+        {"name": "Sally", "age": 33},
+        {"name": "Jim", "age": 42}
+    ],
+    "bindings": {},
+    "result": {"name": "Bill", "age": 35}
+}


### PR DESCRIPTION
For the case where a path expression with a sort expression as the first step is applied to input data with a top level array, then an unhandled javascript error gets passed back to the user.  There are three separate parts to this fix:
1. The sort function needs to be more tolerant of receiving non-arrays
2. The parser needs to flag the sort expression as one that doesn't iterate over its input (much like the array constructor)
3. The flag in step 2 needs to bubble up through `block` nodes in the AST.

Resolves #210 