### PR TITLE
Packaging fixes, phase two

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 coverage/
 node_modules/
+dist/
 doc/
 jsonata.js
 jsonata-es5.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage/
+dist/
 doc/
 jsonata.js
 jsonata.min.js

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-transform-regenerator": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.5.2",
     "babel-runtime": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "pretest": "npm run lint",
     "mocha": "node ./node_modules/istanbul/lib/cli.js cover --report cobertura --report html ./node_modules/mocha/bin/_mocha -- \"test/**/*.js\"",
     "test": "npm run mocha",
-    "posttest": "npm run check-coverage && npm run copy && npm run mkdirp-es6 && npm run babel-es6 && npm run browserify-es6 && npm run minify && npm run babel && npm run browserify && npm run minify-es5",
-    "copy": "ncp src/jsonata.js ./jsonata.js",
+    "posttest": "npm run check-coverage && npm run mkdirp-es6 && npm run babel-es6 && npm run browserify-es6 && npm run minify && npm run babel && npm run browserify && npm run minify-es5",
     "mkdirp-es6": "mkdirp ./dist/es",
     "babel-es6": "babel --no-babelrc --plugins transform-regenerator --out-file dist/es/jsonata.js src/jsonata.js",
     "browserify-es6": "browserify dist/es/jsonata.js --outfile jsonata.js --standalone jsonata",
@@ -54,7 +53,6 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
     "mocha-lcov-reporter": "^1.2.0",
-    "ncp": "^2.0.0",
     "request": "^2.81.0",
     "uglify-es": "^3.0.20"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
     "pretest": "npm run lint",
     "mocha": "node ./node_modules/istanbul/lib/cli.js cover --report cobertura --report html ./node_modules/mocha/bin/_mocha -- \"test/**/*.js\"",
     "test": "npm run mocha",
-    "posttest": "npm run check-coverage && npm run copy && npm run minify && npm run babel && npm run browserify && npm run minify-es5",
+    "posttest": "npm run check-coverage && npm run copy && npm run mkdirp-es6 && npm run babel-es6 && npm run browserify-es6 && npm run minify && npm run babel && npm run browserify && npm run minify-es5",
     "copy": "ncp src/jsonata.js ./jsonata.js",
+    "mkdirp-es6": "mkdirp ./dist/es",
+    "babel-es6": "babel --no-babelrc --plugins transform-regenerator --out-file dist/es/jsonata.js src/jsonata.js",
+    "browserify-es6": "browserify dist/es/jsonata.js --outfile jsonata.js --standalone jsonata",
     "check-coverage": "istanbul check-coverage -statement 100 -branch 100 -function 100 -line 100",
     "minify": "uglifyjs jsonata.js -o jsonata.min.js --compress --mangle",
     "lint": "eslint .",
@@ -48,6 +51,7 @@
     "eslint-plugin-ideal": "^0.1.3",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
     "mocha-lcov-reporter": "^1.2.0",
     "ncp": "^2.0.0",
@@ -56,5 +60,8 @@
   },
   "engines": {
     "node": ">= 4"
+  },
+  "dependencies": {
+    "regenerator-runtime": "^0.11.1"
   }
 }

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -9,6 +9,8 @@
  * @description JSON query and transformation language
  */
 
+var regeneratorRuntime = require("regenerator-runtime");
+
 /**
  * jsonata
  * @function


### PR DESCRIPTION
Continues from #231. This one probably warrants a little debate.

Okay so the basic observation from #214, #211 and #202 is that several consumers are attempting to directly consume `./jsonata.js`, which currently makes use of the ES6 generator syntax, which does not have good support. The solution to this problem is to [compile the ES6 generator syntax away at build time using Babel](https://babeljs.io/docs/plugins/transform-regenerator), so that `./src/jsonata.js` can still use generators while the output file `./jsonata.js` does not. However, compiling the ES6 generator syntax away also requires us to pull in JSONata's first-ever third-party dependency, `regenerator-runtime`.

With this PR,

* The `npm` task `copy`, which simply copied `./src/jsonata.js` to `./jsonata.js`, is removed.
  * The development dependency on `ncp` is removed.
* A new `npm` task `mkdirp-es6` has been added, which creates a directory `./dist/es`, which is currently **not shipped or used** (but wait and see...).
  * A development dependency `mkdirp` has been added.
  * `./dist` has been added to `.eslintignore` and `.gitignore`.
* Another new `npm` task `babel-es6` has been added, which uses Babel and the `transform-regenerator` plugin to convert `./src/jsonata.js` (with ES6 generators) into `./dist/es/jsonata.js` (with no generators).
  * A development dependency on `babel-plugin-transform-regenerator` has been added.
* And a third new `npm` task `browserify-es6` has been added, which uses Browserify to prepare `./dist/es/jsonata.js` as the output UMD we are all familiar with, `./jsonata.js`.
* `./src/jsonata.js` now `require`s `regenerator-runtime`.
  * `regenerator-runtime` has been added to `package.json` as a dependency.

Basically: instead of just copying `./src/jsonata.js` to its destination at `./jsonata.js`, we now Babelify and then Browserify it.

This *should* resolve these consumers' problems...