### PR TITLE
Indicate tests that return unordered arrays.

### DIFF
--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -14,6 +14,14 @@ var jsonata = require("../src/jsonata");
 var chai = require("chai");
 var expect = chai.expect;
 
+var testdata1 = {
+    "foo": {
+        "bar": 42,
+        "blah": [{"baz": {"fud": "hello"}}, {"baz": {"fud": "world"}}, {"bazz": "gotcha"}],
+        "blah.baz": "here"
+    }, "bar": 98
+};
+
 var testdata2 = {
     Account: {
         "Account Name": "Firefly",
@@ -175,6 +183,32 @@ describe("Functions with side-effects", () => {
                 var expected = false;
                 expect(result).to.deep.equal(expected);
             });
+        });
+    });
+});
+
+describe("Tests that rely on JavaScript-style object traversal", () => {
+    // A JSON object is an unordered list of key-value pairs.
+    // When traversing an object, the entries may be returned
+    // in a non-deterministic order (depending on the language).
+    // The following tests assume a traversal order which works
+    // in JavaScript but may not apply to other languages.
+    // See https://github.com/jsonata-js/jsonata/issues/179.
+    describe('foo.*[0]', function () {
+        it('should return result object', function () {
+            var expr = jsonata('foo.*[0]');
+            var result = expr.evaluate(testdata1);
+            var expected = 42;
+            expect(result).to.deep.equal(expected);
+        });
+    });
+
+    describe('**[2]', function () {
+        it('should return result object', function () {
+            var expr = jsonata('**[2]');
+            var result = expr.evaluate(testdata2);
+            var expected = "Firefly";
+            expect(result).to.deep.equal(expected);
         });
     });
 });

--- a/test/test-suite/groups/descendent-operator/case015.json
+++ b/test/test-suite/groups/descendent-operator/case015.json
@@ -1,6 +1,6 @@
 {
-    "expr": "**[2]",
+    "expr": "Account.Order.blah.**",
     "dataset": "dataset5",
     "bindings": {},
-    "result": "Firefly"
+    "undefinedResult": true
 }

--- a/test/test-suite/groups/descendent-operator/case016.json
+++ b/test/test-suite/groups/descendent-operator/case016.json
@@ -1,6 +1,6 @@
 {
-    "expr": "Account.Order.blah.**",
-    "dataset": "dataset5",
+    "expr": "**",
+    "dataset": null,
     "bindings": {},
     "undefinedResult": true
 }

--- a/test/test-suite/groups/descendent-operator/case017.json
+++ b/test/test-suite/groups/descendent-operator/case017.json
@@ -1,6 +1,0 @@
-{
-    "expr": "**",
-    "dataset": null,
-    "bindings": {},
-    "undefinedResult": true
-}

--- a/test/test-suite/groups/function-each/case000.json
+++ b/test/test-suite/groups/function-each/case000.json
@@ -6,5 +6,6 @@
         "Street: Hursley Park",
         "City: Winchester",
         "Postcode: SO21 2JN"
-    ]
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/function-keys/case000.json
+++ b/test/test-suite/groups/function-keys/case000.json
@@ -5,5 +5,6 @@
     "result": [
         "Account Name",
         "Order"
-    ]
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/function-keys/case001.json
+++ b/test/test-suite/groups/function-keys/case001.json
@@ -9,5 +9,6 @@
         "Description",
         "Price",
         "Quantity"
-    ]
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/function-spread/case001.json
+++ b/test/test-suite/groups/function-spread/case001.json
@@ -63,5 +63,6 @@
         {
             "Weight": 2
         }
-    ]
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/wildcards/case000.json
+++ b/test/test-suite/groups/wildcards/case000.json
@@ -18,5 +18,6 @@
             "bazz": "gotcha"
         },
         "here"
-    ]
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/wildcards/case006.json
+++ b/test/test-suite/groups/wildcards/case006.json
@@ -1,6 +1,19 @@
 {
-    "expr": "foo.*[0]",
-    "dataset": "dataset0",
+    "expr": "*[type=\"home\"]",
+    "dataset": "dataset1",
     "bindings": {},
-    "result": 42
+    "result": [
+        {
+            "type": "home",
+            "number": "0203 544 1234"
+        },
+        {
+            "type": "home",
+            "address": [
+                "freddy@my-social.com",
+                "frederic.smith@very-serious.com"
+            ]
+        }
+    ],
+    "unordered": true
 }

--- a/test/test-suite/groups/wildcards/case007.json
+++ b/test/test-suite/groups/wildcards/case007.json
@@ -1,18 +1,9 @@
 {
-    "expr": "*[type=\"home\"]",
-    "dataset": "dataset1",
+    "expr": "Account[$$.Account.\"Account Name\" = \"Firefly\"].*[OrderID=\"order104\"].Product.Price",
+    "dataset": "dataset5",
     "bindings": {},
     "result": [
-        {
-            "type": "home",
-            "number": "0203 544 1234"
-        },
-        {
-            "type": "home",
-            "address": [
-                "freddy@my-social.com",
-                "frederic.smith@very-serious.com"
-            ]
-        }
+        34.45,
+        107.99
     ]
 }

--- a/test/test-suite/groups/wildcards/case008.json
+++ b/test/test-suite/groups/wildcards/case008.json
@@ -1,5 +1,5 @@
 {
-    "expr": "Account[$$.Account.\"Account Name\" = \"Firefly\"].*[OrderID=\"order104\"].Product.Price",
+    "expr": "Account[$$.Account.`Account Name` = \"Firefly\"].*[OrderID=\"order104\"].Product.Price",
     "dataset": "dataset5",
     "bindings": {},
     "result": [

--- a/test/test-suite/groups/wildcards/case009.json
+++ b/test/test-suite/groups/wildcards/case009.json
@@ -1,9 +1,0 @@
-{
-    "expr": "Account[$$.Account.`Account Name` = \"Firefly\"].*[OrderID=\"order104\"].Product.Price",
-    "dataset": "dataset5",
-    "bindings": {},
-    "result": [
-        34.45,
-        107.99
-    ]
-}


### PR DESCRIPTION
This PR addresses issue [#179: Test suite relies on JavaScript object traversal](https://github.com/jsonata-js/jsonata/issues/179).

- Six tests in the test suite have a new "unordered" flag indicating that their results are not in a fixed order.

- Two tests have been moved from the language-agnostic test suite to the JavaScript test file.

Note: In the two cases where test files were deleted, subsequent files were renamed to avoid gaps in the numbering. For example, after deleting the wildcard test file `case006.json`, `case007.json` was renamed to `case006.json` and `case008.json` was renamed to `case007.json`. This might be overkill. Perhaps it would be better to keep these filenames consistent across releases.