### PR TITLE
Translate symbol in array type error to full plural of type

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -70,6 +70,17 @@ var jsonata = (function() {
         't': '\t'
     };
 
+    // A mapping between the function signature symbols and the full plural of the type
+    // Expected to be used in error messages
+    var arraySignatureMapping = {
+        "a": "arrays",
+        "b": "booleans",
+        "f": "functions",
+        "n": "numbers",
+        "o": "objects",
+        "s": "strings"
+    }
+
     // Tokenizer (lexer) - invoked by the parser to return one token at a time
     var tokenizer = function (path) {
         var position = 0;
@@ -575,7 +586,7 @@ var jsonata = (function() {
                                                 stack: (new Error()).stack,
                                                 value: arg,
                                                 index: argIndex + 1,
-                                                type: param.subtype // TODO translate symbol to type name
+                                                type: arraySignatureMapping[param.subtype]
                                             };
                                         }
                                         // the function expects an array. If it's not one, make it so


### PR DESCRIPTION
This is a change to resolve a `TODO` in the code for error `T0412` where the argument supplied to a function that operates on arrays contains an array of different types to what was specified in the function signature. At present is just returns the symbol (`a`, `s`, etc.), but it should return an English string that is more descriptive; that is, the full plural of the type (`arrays`, `strings`, etc.)

We expose this error straight through to the user in the UI in App Connect so we wanted to make it clearer why they should not be using `$join()` (for example) with an array of objects.

I've tried to go for the simplest implementation here just using a static object that the error object references with a key; this could become a function if we wanted to add more protection, but as the key passed in is based on the symbols in the signature and not the user input we have a narrower scope of things to worry about. I'm happy to change this if necessary.

The other thing I'm calling out here is that I haven't added any tests; none of the JSONata tests look at the error messages (intentionally), so modifying the contents of that message does not cause failures or coverage problems. I'm not fully comfortable with this, but didn't want to interfere with the cross-implementation test suite; if adding a test is necessary then it might just be a more traditional one in the implementation suite, but it would be vulnerable to the message changing, which I believe is why none of the messages are checked at present.