### PR TITLE
Handle DOMExceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.0",
+    "domexception": "^1.0.1",
     "eslint": "^4.0.0",
     "eslint-plugin-ideal": "^0.1.3",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.0",
-    "domexception": "^1.0.1",
     "eslint": "^4.0.0",
     "eslint-plugin-ideal": "^0.1.3",
     "istanbul": "^0.4.5",

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -4939,18 +4939,14 @@ var jsonata = (function() {
 
     /**
      * lookup a message template from the catalog and substitute the inserts.
-     * Populates `err.message` with the substituted message.
+     * Populates `err.message` with the substituted message. Leaves `err.message`
+     * untouched if code lookup fails.
      * @param {string} err - error code to lookup
      * @returns {undefined} - `err` is modified in place
      */
     function populateMessage(err) {
         var template = errorCodes[err.code];
-        if(typeof template === 'undefined') {
-            if(typeof err.message === 'undefined') {
-                err.message = 'Unknown error';
-            }
-            // Otherwise retain the original `err.message`
-        } else {
+        if(typeof template !== 'undefined') {
             // if there are any handlebars, replace them with the field references
             // triple braces - replace with value
             // double braces - replace with json stringified value
@@ -4962,6 +4958,7 @@ var jsonata = (function() {
             });
             err.message = message;
         }
+        // Otherwise retain the original `err.message`
     }
 
     /**

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -5024,7 +5024,10 @@ var jsonata = (function() {
                 if(typeof callback === 'function') {
                     exec_env.bind('__jsonata_async', true);
                     var catchHandler = function (err) {
-                        err.message = lookupMessage(err);
+                        var message = lookupMessage(err);
+                        if (err.message !== message) {
+                            err.message = message
+                        }
                         callback(err, null);
                     };
                     var thenHandler = function (response) {
@@ -5049,7 +5052,10 @@ var jsonata = (function() {
                         return result.value;
                     } catch (err) {
                         // insert error message into structure
-                        err.message = lookupMessage(err);
+                        var message = lookupMessage(err);
+                        if (err.message !== message) {
+                            err.message = message
+                        }
                         throw err;
                     }
                 }

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -318,16 +318,9 @@ describe("Tests that bind Javascript functions", () => {
             });
         }
 
-        Object.defineProperty(DOMException.prototype, Symbol.toStringTag, {
-            value: "DOMException",
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
-
         Object.setPrototypeOf(DOMException.prototype, Error.prototype);
 
-        it("rethrows correctly when invoked synchronously", function() {
+        it("rethrows correctly", function() {
             var expr = jsonata("$throwDomEx()");
             expr.registerFunction("throwDomEx", function() {
                 throw new DOMException('Here is my message');
@@ -337,19 +330,6 @@ describe("Tests that bind Javascript functions", () => {
             })
                 .to.throw(DOMException)
                 .to.deep.contain({ message: 'Here is my message', position: 12, token: 'throwDomEx' });
-        });
-
-        it("rethrows correctly when invoked asynchronously", function (done) {
-            var expr = jsonata("$throwDomEx()");
-            expr.registerFunction("throwDomEx", function() {
-                throw new DOMException('Here is my message');
-            });
-            expr.evaluate({}, undefined, function (err) {
-                expect(err)
-                    .to.be.a('DOMException')
-                    .to.deep.contain({ message: 'Here is my message', position: 12, token: 'throwDomEx' });
-                done();
-            });
         });
     });
 

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -299,8 +299,8 @@ describe("Tests that bind Javascript functions", () => {
 
     // Issue #261. Previously we would attempt to assign to the read-only `message` property,
     // causing an unrelated `TypeError` to be thrown instead
-    describe("User-defined function throws a `DOMException` with a read-only `message` property", function() {
-        it("Rethrows correctly", function() {
+    describe("function throws a `DOMException` with a read-only `message` property", function() {
+        it("rethrows correctly when invoked synchronously", function() {
             var expr = jsonata("$throwDomEx()");
             expr.registerFunction("throwDomEx", function() {
                 throw new DOMException('Here is my message');
@@ -312,7 +312,7 @@ describe("Tests that bind Javascript functions", () => {
                 .to.deep.contain({ message: 'Here is my message', position: 12, token: 'throwDomEx' });
         });
 
-        it("Rethrows correctly when invoked asynchronously", function (done) {
+        it("rethrows correctly when invoked asynchronously", function (done) {
             var expr = jsonata("$throwDomEx()");
             expr.registerFunction("throwDomEx", function() {
                 throw new DOMException('Here is my message');


### PR DESCRIPTION
Fixes #261.

I fixed this by modifying (simplifying) `lookupMessage`.

* `lookupMessage` is now named `populateMessage`. Rather than return a string, it now populates `err.message` as a side-effect (or leaves it as is, if appropriate).
* Generally speaking, `populateMessage` now explicitly expects `err` to be either
  1. a plain old JavaScript object with an error `code`, thrown by `jsonata` itself, whose `message` should be populated using the appropriate template, or
  2. an actual `Error` object or similar (such as a `DOMException`) with no `code`, but with an existing `message` property which should not be touched.

Note that logic which automatically reified an error message of `"Unknown error"` was untested and therefore apparently unused, and so has been removed. The only way to hit this case was for a user to deliberately define a function which threw a non-`Error`, which I think is a rare case and not worth adding a test for.