### PR TITLE
consistent handling of function params for HOFs

### DIFF
--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -384,7 +384,7 @@ describe("Tests that bind Javascript functions", () => {
         });
     });
 
-    describe("sift with a user-defined Javascript function", function() {
+    describe("$sift with a user-defined Javascript function", function() {
         it("should return result object", function() {
             var expr = jsonata("$sift({'one': 1, 'four': 4, 'nine': 9, 'sixteen': 16}, $even)");
             expr.assign("even", function(num) {

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -372,6 +372,42 @@ describe("Tests that bind Javascript functions", () => {
         });
     });
 
+    describe("filter with a user-defined Javascript function", function() {
+        it("should return result object", function() {
+            var expr = jsonata("$filter([1,4,9,16], $even)");
+            expr.assign("even", function(num) {
+                return num % 2 === 0;
+            });
+            var result = expr.evaluate(testdata2);
+            var expected = [4, 16];
+            expect(result).to.deep.equal(expected);
+        });
+    });
+
+    describe("sift with a user-defined Javascript function", function() {
+        it("should return result object", function() {
+            var expr = jsonata("$sift({'one': 1, 'four': 4, 'nine': 9, 'sixteen': 16}, $even)");
+            expr.assign("even", function(num) {
+                return num % 2 === 0;
+            });
+            var result = expr.evaluate(testdata2);
+            var expected = {'four': 4, 'sixteen': 16};
+            expect(result).to.deep.equal(expected);
+        });
+    });
+
+    describe("$each with a user-defined Javascript function", function() {
+        it("should return result object", function() {
+            var expr = jsonata("$each({'one': 1, 'four': 4, 'nine': 9, 'sixteen': 16}, $squareroot)");
+            expr.assign("squareroot", function(num) {
+                return Math.sqrt(num);
+            });
+            var result = expr.evaluate(testdata2);
+            var expected = [1, 2, 3, 4];
+            expect(result).to.deep.equal(expected);
+        });
+    });
+
     describe("Partially apply user-defined Javascript function", function() {
         it("should return result object", function() {
             var expr = jsonata(

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -372,7 +372,7 @@ describe("Tests that bind Javascript functions", () => {
         });
     });
 
-    describe("filter with a user-defined Javascript function", function() {
+    describe("$filter with a user-defined Javascript function", function() {
         it("should return result object", function() {
             var expr = jsonata("$filter([1,4,9,16], $even)");
             expr.assign("even", function(num) {

--- a/test/test-suite/groups/function-each/case001.json
+++ b/test/test-suite/groups/function-each/case001.json
@@ -1,0 +1,7 @@
+{
+    "expr": "$each({'a': 'hello', 'b': 'world'}, $uppercase)",
+    "dataset": "dataset1",
+    "bindings": {},
+    "result": ["HELLO", "WORLD"],
+    "unordered": true
+}

--- a/test/test-suite/groups/function-sift/case003.json
+++ b/test/test-suite/groups/function-sift/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$sift({'a': 1, 'b': 0}, $boolean)",
+    "dataset": "dataset1",
+    "bindings": {},
+    "result": {"a": 1}
+}

--- a/test/test-suite/groups/function-sift/case004.json
+++ b/test/test-suite/groups/function-sift/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$sift({'a': 'hello', 'b': 'world', 'hello': 'again'}, λ($v,$k,$o){$lookup($o, $v)})",
+    "dataset": "dataset1",
+    "bindings": {},
+    "result": {"a": "hello"}
+}

--- a/test/test-suite/groups/hof-filter/case003.json
+++ b/test/test-suite/groups/hof-filter/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$filter([0, 1, 2], $boolean)",
+    "data": {"data": 5},
+    "bindings": {},
+    "result": [1,2]
+}

--- a/test/test-suite/groups/hof-map/case009.json
+++ b/test/test-suite/groups/hof-map/case009.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$map([0, 1, 2], $boolean)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": [false, true, true]
+}


### PR DESCRIPTION
The handling of optional arguments for the function arg passed to $filter, $each & $sift should be consistent with the correct behaviour in $map.
resolves #233 
resolves #250 