### PR TITLE
keepArray syntax should apply to all expression types

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1410,6 +1410,9 @@ var jsonata = (function() {
                         throw err;
                     }
             }
+            if(expr.keepArray) {
+                result.keepArray = true;
+            }
             return result;
         };
 
@@ -1594,6 +1597,9 @@ var jsonata = (function() {
         }
 
         if(result && result.sequence) {
+            if(expr.keepArray) {
+                result.keepSingleton = true;
+            }
             result = result.value();
         }
 

--- a/test/test-suite/groups/flattening/case042.json
+++ b/test/test-suite/groups/flattening/case042.json
@@ -1,0 +1,5 @@
+{
+    "expr": "$[type='command'][]",
+    "data": [{"type":"command"},{"type":"commands"}],
+    "result": [{"type":"command"}]
+}

--- a/test/test-suite/groups/flattening/case043.json
+++ b/test/test-suite/groups/flattening/case043.json
@@ -1,0 +1,5 @@
+{
+    "expr": "$[][type='command']",
+    "data": [{"type":"command"},{"type":"commands"}],
+    "result": [{"type":"command"}]
+}

--- a/test/test-suite/groups/flattening/case044.json
+++ b/test/test-suite/groups/flattening/case044.json
@@ -1,0 +1,5 @@
+{
+    "expr": "$filter($, function($e) { $e != 0 })[]",
+    "data": [0,0,5,0],
+    "result": [5]
+}


### PR DESCRIPTION
'keep array' syntax `[]` should apply to any expression type, not just location paths.

resolves #236 