### PR TITLE
check for object should not include arrays

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -2593,7 +2593,7 @@ var jsonata = (function() {
                     // update must be an object
                     var updateType = typeof update;
                     if(updateType !== 'undefined') {
-                        if(updateType !== 'object' || update === null) {
+                        if(updateType !== 'object' || update === null || Array.isArray(update)) {
                             // throw type error
                             throw {
                                 code: "T2011",

--- a/test/test-suite/groups/transforms/case012.json
+++ b/test/test-suite/groups/transforms/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "{} ~> |$|['one', 'two', 'three']|",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "T2011"
+}


### PR DESCRIPTION
The 'update' part of the transform syntax should only allow JSON objects to be specified.  However, arrays were being accepted because a JS array is an object.  An extra check was added.

resolves #245 