### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.0",
-    "eslint": "^5.8.0",
+    "eslint": "^4.0.0",
     "eslint-plugin-ideal": "^0.1.3",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.0",
-    "eslint": "^4.0.0",
+    "eslint": "^5.8.0",
     "eslint-plugin-ideal": "^0.1.3",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
@@ -61,6 +61,6 @@
     "node": ">= 4"
   },
   "dependencies": {
-    "regenerator-runtime": "^0.11.1"
+    "regenerator-runtime": "^0.12.1"
   }
 }


### PR DESCRIPTION
Updating the `eslint` and `regenerator-runtime` dependencies to their latest versions. Neither require any code changes to be made, so this is just a simple update of `package.json` to keep up with current.