### PR TITLE
Release version 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+#### 1.6.2 Maintenance Release
+
+- Fix insertion of regenerator runtime at top of ES5 file (PR #284)
+
 #### 1.6.1 Milestone Release (v1.6.0 was not published)
 
 - New date/time formatting and parsing capability (issue #166)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonata",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "JSON query and transformation language",
   "module": "jsonata.js",
   "main": "jsonata.js",


### PR DESCRIPTION
Release patch to fix generated `jsonata-es5.js` (https://github.com/jsonata-js/jsonata/pull/284)