### PR TITLE
fix ES5 build to run test suite in nashorn

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check-coverage": "istanbul check-coverage -statement 100 -branch 100 -function 100 -line 100",
     "browserify": "browserify src/jsonata.js --outfile jsonata.js --standalone jsonata",
     "mkdir-dist": "mkdirp ./dist",
-    "regenerator": "regenerator src dist",
+    "regenerator": "babel src --out-dir dist --presets=@babel/env",
     "browserify-es5": "regenerator --include-runtime polyfill.js > jsonata-es5.js; browserify dist/jsonata.js --standalone jsonata >> jsonata-es5.js",
     "prepublishOnly": "npm run browserify && npm run minify && npm run build-es5",
     "lint": "eslint src",
@@ -39,6 +39,9 @@
     "path"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.2.0",
+    "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.2.0",
     "browserify": "^16.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/polyfill.js
+++ b/polyfill.js
@@ -93,3 +93,55 @@ if (!Array.from) {
     }());
 }
 
+if (!String.fromCodePoint) (function(stringFromCharCode) {
+    var fromCodePoint = function(_) {
+        var codeUnits = [], codeLen = 0, result = "";
+        for (var index=0, len = arguments.length; index !== len; ++index) {
+            var codePoint = +arguments[index];
+            // correctly handles all cases including `NaN`, `-Infinity`, `+Infinity`
+            // The surrounding `!(...)` is required to correctly handle `NaN` cases
+            // The (codePoint>>>0) === codePoint clause handles decimals and negatives
+            if (!(codePoint < 0x10FFFF && (codePoint>>>0) === codePoint))
+                throw RangeError("Invalid code point: " + codePoint);
+            if (codePoint <= 0xFFFF) { // BMP code point
+                codeLen = codeUnits.push(codePoint);
+            } else { // Astral code point; split in surrogate halves
+                // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+                codePoint -= 0x10000;
+                codeLen = codeUnits.push(
+                    (codePoint >> 10) + 0xD800,  // highSurrogate
+                    (codePoint % 0x400) + 0xDC00 // lowSurrogate
+                );
+            }
+            if (codeLen >= 0x3fff) {
+                result += stringFromCharCode.apply(null, codeUnits);
+                codeUnits.length = 0;
+            }
+        }
+        return result + stringFromCharCode.apply(null, codeUnits);
+    };
+    try { // IE 8 only supports `Object.defineProperty` on DOM elements
+        Object.defineProperty(String, "fromCodePoint", {
+            "value": fromCodePoint, "configurable": true, "writable": true
+        });
+    } catch(e) {
+        String.fromCodePoint = fromCodePoint;
+    }
+}(String.fromCharCode));
+
+if (!Object.is) {
+    Object.is = function(x, y) {
+        // SameValue algorithm
+        if (x === y) { // Steps 1-5, 7-10
+            // Steps 6.b-6.e: +0 != -0
+            return x !== 0 || 1 / x === 1 / y;
+        } else {
+            // Step 6.a: NaN == NaN
+            return x !== x && y !== y;
+        }
+    };
+}
+
+Math.log10 = Math.log10 || function(x) {
+    return Math.log(x) * Math.LOG10E;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,6 +150,11 @@ const utils = (() => {
         return arg && arg._jsonata_lambda === true;
     }
 
+    // istanbul ignore next
+    var $Symbol = typeof Symbol === "function" ? Symbol : {};
+    // istanbul ignore next
+    var iteratorSymbol = $Symbol.iterator || "@@iterator";
+
     /**
      * @param {Object} arg - expression to test
      * @returns {boolean} - true if it is iterable
@@ -158,7 +163,7 @@ const utils = (() => {
         return (
             typeof arg === 'object' &&
             arg !== null &&
-            Symbol.iterator in arg &&
+            iteratorSymbol in arg &&
             'next' in arg &&
             typeof arg.next === 'function'
         );


### PR DESCRIPTION
Changes made to the es5 build and polyfills to get jsonata-es5.js up to scratch for running the test suite in Java Nashorn.  This is representative of a barebones ES5 implementation.
Most of the tests now run under nashorn with the exception of:
- tests involving multibyte unicode strings (might need extra polyfills here)
- case insensitive regexes (for some reason)
- base64 encode/decode functions

resolves #287 (hopefully)