### PR TITLE
$each should not result in undefined values in the result object

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1630,7 +1630,10 @@ const functions = (() => {
         for (var key in obj) {
             var func_args = hofFuncArgs(func, obj[key], key, obj);
             // invoke func
-            result.push(yield* func.apply(this, func_args));
+            var val = yield* func.apply(this, func_args);
+            if(typeof val !== 'undefined') {
+                result.push(val);
+            }
         }
 
         return result;

--- a/test/test-suite/groups/function-each/case002.json
+++ b/test/test-suite/groups/function-each/case002.json
@@ -1,0 +1,7 @@
+{
+    "expr": "$each(function($v, $k) {$k[$v>2]})",
+    "data": { "a": 1, "b": 2, "c": 3, "d": 4 },
+    "bindings": {},
+    "result": ["c", "d"],
+    "unordered": true
+}


### PR DESCRIPTION
`$each()` returns an array of values by applying a supplied function to each name/value pair in a given object.  If that function returns `undefined` (no match / empty sequence), then that `undefined` value is getting added to the result sequence.  It shouldn't - it should be flattened out.