### PR TITLE
Add details on how to get Slack invite to docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,9 +4,15 @@ title: Contributing to JSONata
 sidebar_label: Community and Contributing
 ---
 
-## General questions - StackOverflow
+## General questions
 
-See questions [tagged with `jsonata`](https://stackoverflow.com/questions/tagged/jsonata)
+### StackOverflow
+
+A good first start would be to ask a question here, or see previous questions [tagged with `jsonata`](https://stackoverflow.com/questions/tagged/jsonata)
+
+### Slack
+
+There are a community of users in the [JSONata Slack workspace](http://jsonata.slack.com) who can help with queries. You can request an invite by going to the [JSONata exerciser](http://try.jsonata.org/) and clicking the Slack icon in the top-left.
 
 ## Bugs reporting
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ A good first start would be to ask a question here, or see previous questions [t
 
 ### Slack
 
-There are a community of users in the [JSONata Slack workspace](http://jsonata.slack.com) who can help with queries. You can request an invite by going to the [JSONata exerciser](http://try.jsonata.org/) and clicking the Slack icon in the top-left.
+There are a community of users in the [JSONata Slack workspace](http://jsonata.slack.com) who can help with queries. You can request an invite by going to the [JSONata exerciser](http://try.jsonata.org/) and clicking the Slack icon in the top-right.
 
 ## Bugs reporting
 


### PR DESCRIPTION
Fixes https://github.com/jsonata-js/jsonata-js.github.io/issues/11

Small doc update to explain how to request an invite to the Slack workspace, both to fix the above issue and as this came up again as an issue recently.