### PR TITLE
Add $error() function.

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1640,6 +1640,19 @@ const functions = (() => {
     }
 
     /**
+     *
+     * @param {string} [message] - the message to attach to the error
+     * @throws custom error with code 'D3137'
+     */
+    function error(message) {
+        throw {
+            code: "D3137",
+            stack: (new Error()).stack,
+            message: message || "$error() function evaluated"
+        };
+    }
+
+    /**
      * Implements the merge sort (stable) with optional comparator function
      *
      * @param {Array} arr - the array to sort
@@ -1778,7 +1791,7 @@ const functions = (() => {
         formatNumber, formatBase, number, floor, ceil, round, abs, sqrt, power, random,
         boolean, not,
         map, zip, filter, foldLeft, sift,
-        keys, lookup, append, exists, spread, merge, reverse, each, sort, shuffle,
+        keys, lookup, append, exists, spread, merge, reverse, each, error, sort, shuffle,
         base64encode, base64decode
     };
 })();

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1699,6 +1699,7 @@ var jsonata = (function() {
     staticFrame.bind('merge', defineFunction(fn.merge, '<a<o>:o>'));
     staticFrame.bind('reverse', defineFunction(fn.reverse, '<a:a>'));
     staticFrame.bind('each', defineFunction(fn.each, '<o-f:a>'));
+    staticFrame.bind('error', defineFunction(fn.error, '<s?:x>'));
     staticFrame.bind('sort', defineFunction(fn.sort, '<af?:a>'));
     staticFrame.bind('shuffle', defineFunction(fn.shuffle, '<a:a>'));
     staticFrame.bind('base64encode', defineFunction(fn.base64encode, '<s-:s>'));

--- a/test/test-suite/groups/function-error/case000.json
+++ b/test/test-suite/groups/function-error/case000.json
@@ -1,0 +1,6 @@
+{
+    "expr": "Account.Order[0].Product[0].Price > 35 ? Account.Order[0].Product[0].Price : $error('Too Expensive')",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}

--- a/test/test-suite/groups/function-error/case001.json
+++ b/test/test-suite/groups/function-error/case001.json
@@ -1,0 +1,6 @@
+{
+    "expr": "Account.Order[0].Product[0].Price > 34 ? Account.Order[0].Product[0].Price : $error('Too Expensive')",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": 34.45
+}

--- a/test/test-suite/groups/function-error/case002.json
+++ b/test/test-suite/groups/function-error/case002.json
@@ -1,0 +1,6 @@
+{
+    "expr": "Account.Order[0].Product[0].Price > 35 ? $error('Too Expensive') : Account.Order[0].Product[0].Price",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": 34.45
+}

--- a/test/test-suite/groups/function-error/case003.json
+++ b/test/test-suite/groups/function-error/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "Account.Order[0].Product[0].Price > 34 ? $error('Too Expensive') : Account.Order[0].Product[0].Price",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}

--- a/test/test-suite/groups/function-error/case004.json
+++ b/test/test-suite/groups/function-error/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$count(Account.Order[0].Product) < 2 ? $error('Not enough products in orders')",
+    "dataset": "dataset5",
+    "bindings": {},
+    "undefinedResult": true
+}

--- a/test/test-suite/groups/function-error/case005.json
+++ b/test/test-suite/groups/function-error/case005.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$count(Account.Order[0].Product) < 3 ? $error('Not enough products in orders')",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}

--- a/test/test-suite/groups/function-error/case006.json
+++ b/test/test-suite/groups/function-error/case006.json
@@ -1,0 +1,6 @@
+{
+    "expr": "($msg='My Message'; $error($msg); true)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}

--- a/test/test-suite/groups/function-error/case007.json
+++ b/test/test-suite/groups/function-error/case007.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$error(null)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "T0410"
+}

--- a/test/test-suite/groups/function-error/case008.json
+++ b/test/test-suite/groups/function-error/case008.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$error(5)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "T0410"
+}

--- a/test/test-suite/groups/function-error/case009.json
+++ b/test/test-suite/groups/function-error/case009.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$error()",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}

--- a/test/test-suite/groups/function-error/case010.json
+++ b/test/test-suite/groups/function-error/case010.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$error(foo)",
+    "dataset": "dataset5",
+    "bindings": {},
+    "code": "D3137"
+}


### PR DESCRIPTION
Proposed in https://github.com/jsonata-js/jsonata/issues/167

Implementation notes:
* Used error code `D3137` for all errors thrown with this function since it was the next number in the sequence (for dynamically thrown errors from functions).
* There is no template text for this error.
* Message is optional.  Defaults to `$error() function evaluated`