### PR TITLE
Replace deprecated Buffer call

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -553,7 +553,7 @@ const functions = (() => {
                 // Simply doing `new Buffer` at this point causes Browserify to pull
                 // in the entire Buffer browser library, which is large and unnecessary.
                 // Using `global.Buffer` defeats this.
-                return new global.Buffer.from(str, 'binary').toString('base64');
+                return new global.Buffer.from(str, 'binary').toString('base64'); // eslint-disable-line new-cap
             };
         return btoa(str);
     }

--- a/src/functions.js
+++ b/src/functions.js
@@ -553,7 +553,7 @@ const functions = (() => {
                 // Simply doing `new Buffer` at this point causes Browserify to pull
                 // in the entire Buffer browser library, which is large and unnecessary.
                 // Using `global.Buffer` defeats this.
-                return new global.Buffer(str, 'binary').toString('base64');
+                return new global.Buffer.from(str, 'binary').toString('base64');
             };
         return btoa(str);
     }


### PR DESCRIPTION
In recent versions of NodeJS the old calls to the Buffer class (e.g. `Buffer(str, 'binary')`) have been deprecated in favour of new functions (see https://nodejs.org/api/buffer.html#buffer_new_buffer_array). In fact, it's been deprecated through all of the versions of NodeJS that JSONata supports.

This is a simple replacement which should give the same functionality but get rid of the deprecation warnings.