### PR TITLE
allow leading zeros when casting string to number

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1194,7 +1194,7 @@ const functions = (() => {
         if (typeof arg === 'number') {
             // already a number
             result = arg;
-        } else if (typeof arg === 'string' && /^-?(0|([1-9][0-9]*))(\.[0-9]+)?([Ee][-+]?[0-9]+)?$/.test(arg) && !isNaN(parseFloat(arg)) && isFinite(arg)) {
+        } else if (typeof arg === 'string' && /^-?[0-9]+(\.[0-9]+)?([Ee][-+]?[0-9]+)?$/.test(arg) && !isNaN(parseFloat(arg)) && isFinite(arg)) {
             result = parseFloat(arg);
         } else if (arg === true) {
             // boolean true casts to 1

--- a/test/test-suite/groups/function-number/case027.json
+++ b/test/test-suite/groups/function-number/case027.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$number('00')",
+    "dataset": null,
+    "bindings": {},
+    "result": 0
+}

--- a/test/test-suite/groups/function-number/case028.json
+++ b/test/test-suite/groups/function-number/case028.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$number('0123')",
+    "dataset": null,
+    "bindings": {},
+    "result": 123
+}

--- a/test/test-suite/groups/function-number/case029.json
+++ b/test/test-suite/groups/function-number/case029.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$number('-007')",
+    "dataset": null,
+    "bindings": {},
+    "result": -7
+}

--- a/test/test-suite/groups/function-number/case030.json
+++ b/test/test-suite/groups/function-number/case030.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$number('000.00123000')",
+    "dataset": null,
+    "bindings": {},
+    "result": 0.00123
+}


### PR DESCRIPTION
Allow numeric strings to have leading zeros when casting to numbers in `$number()`
resolves #368 