### PR TITLE
Fix deadlink for order-by in docs

### DIFF
--- a/docs/sorting-grouping.md
+++ b/docs/sorting-grouping.md
@@ -10,9 +10,9 @@ Arrays contain an ordered collection of values.  If you need to re-order the val
 
 1. Using the [`$sort()`](array-functions#sort) function.
 
-2. Using the [order-by](control-operators#order-by) operator.
+2. Using the [order-by](path-operators#order-by-) operator.
 
-The [order-by](control-operators#order-by) operator is a convenient syntax that can used directly in a path expression to sort the result sequences in ascending or descending order.  The [`$sort()`](array-functions#sort) function requires more syntax to be written, but is more flexible and supports custom comparator functions.
+The [order-by](path-operators#order-by-) operator is a convenient syntax that can used directly in a path expression to sort the result sequences in ascending or descending order.  The [`$sort()`](array-functions#sort) function requires more syntax to be written, but is more flexible and supports custom comparator functions.
 
 ## Grouping
 


### PR DESCRIPTION
Link should be `path-operators#order-by-` not `control-operators#order-by`