### PR TITLE
Maintain singleton sequence of array

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -219,6 +219,9 @@ var jsonata = (function() {
         }
 
         if(expr.keepSingletonArray) {
+            if(!isSequence(resultSequence)) {
+                resultSequence = createSequence(resultSequence);
+            }
             resultSequence.keepSingleton = true;
         }
 

--- a/test/test-suite/groups/flattening/sequence-of-arrays.json
+++ b/test/test-suite/groups/flattening/sequence-of-arrays.json
@@ -1,0 +1,40 @@
+[
+    {
+        "expr": "$.[value,epochSeconds]",
+        "data": [
+            {"epochSeconds":1578381600,"value": 3},
+            {"epochSeconds":1578381700,"value": 5}
+        ],
+        "result": [
+            [3, 1578381600],
+            [5, 1578381700]
+        ]
+    },
+    {
+        "expr": "$.[value,epochSeconds]",
+        "data": [
+            {"epochSeconds":1578381600,"value": 3}
+        ],
+        "result": [3, 1578381600]
+    },
+    {
+        "expr": "$.[value,epochSeconds][]",
+        "data": [
+            {"epochSeconds":1578381600,"value": 3},
+            {"epochSeconds":1578381700,"value": 5}
+        ],
+        "result": [
+            [3, 1578381600],
+            [5, 1578381700]
+        ]
+    },
+    {
+        "expr": "$.[value,epochSeconds][]",
+        "data": [
+            {"epochSeconds":1578381600,"value": 3}
+        ],
+        "result": [
+            [3, 1578381600]
+        ]
+    }
+]

--- a/test/test-suite/groups/hof-zip-map/case002.json
+++ b/test/test-suite/groups/hof-zip-map/case002.json
@@ -1,5 +1,5 @@
 {
-    "expr": "(  $data := {    \"one\": [1],    \"two\": [5]  };  $data[].$zip(one, two) ~> $map($sum)) ",
+    "expr": "(  $data := {    \"one\": [1],    \"two\": [5]  };  $data.$zip(one, two) ~> $map($sum)) ",
     "data": null,
     "bindings": {},
     "result": 6

--- a/test/test-suite/groups/hof-zip-map/case003.json
+++ b/test/test-suite/groups/hof-zip-map/case003.json
@@ -1,5 +1,5 @@
 {
-    "expr": "(  $data := {    \"one\": 1,    \"two\": 5  };  $data[].$zip(one, two) ~> $map($sum)) ",
+    "expr": "(  $data := {    \"one\": 1,    \"two\": 5  };  $data.$zip(one, two) ~> $map($sum)) ",
     "data": null,
     "bindings": {},
     "result": 6


### PR DESCRIPTION
The `[]` syntax in a path expression should output the result sequence as an array even if the sequence contains one value (singleton sequence).  However, this is not happening if that value is an array.  Instead it's just using that as the result array.  This PR fixes that, so that it will be enclosed in another array.

Resolves #399 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>