### PR TITLE
fix test suite to work in all timezones

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -644,7 +644,7 @@ const dateTime = (function () {
         // the week starts on a Monday - calculate the millis for the start of the first week
         // millis for given 1st Jan of that year (at 00:00 UTC)
         const jan1 = Date.UTC(ym.year, ym.month);
-        var dayOfJan1 = (new Date(jan1)).getDay();
+        var dayOfJan1 = (new Date(jan1)).getUTCDay();
         if (dayOfJan1 === 0) {
             dayOfJan1 = 7;
         }
@@ -1207,8 +1207,8 @@ const dateTime = (function () {
                 const firstJan = Date.UTC(components.Y, 0);
                 const offsetMillis = (components.d - 1) * 1000 * 60 * 60 * 24;
                 const derivedDate = new Date(firstJan + offsetMillis);
-                components.M = derivedDate.getMonth();
-                components.D = derivedDate.getDate();
+                components.M = derivedDate.getUTCMonth();
+                components.D = derivedDate.getUTCDate();
             }
             if (dateC) {
                 // TODO implement this


### PR DESCRIPTION
The test suite failures are caused by careless use of non-UTC Date functions in the date/time parser

resolves #403 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>