### PR TITLE
Reset lastIndex on RegExp objects that get reused in closures

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1089,8 +1089,9 @@ var jsonata = (function() {
      */
     function evaluateRegex(expr) {
         var re = new RegExp(expr.value);
-        var closure = function(str) {
+        var closure = function(str, fromIndex) {
             var result;
+            re.lastIndex = fromIndex || 0;
             var match = re.exec(str);
             if(match !== null) {
                 result = {
@@ -1108,7 +1109,7 @@ var jsonata = (function() {
                     if(re.lastIndex >= str.length) {
                         return undefined;
                     } else {
-                        var next = closure(str);
+                        var next = closure(str, re.lastIndex);
                         if(next && next.match === '') {
                             // matches zero length string; this will never progress
                             throw {

--- a/test/test-suite/groups/regex/case037.json
+++ b/test/test-suite/groups/regex/case037.json
@@ -1,0 +1,28 @@
+{
+    "expr": "$map($, $match(?, /^(\\w*\\s\\w*)/)).match",
+    "data": [
+        "Felicia Saunders",
+        "Jimmy Schultz",
+        "Dolores Figueroa",
+        "Craig Moreno",
+        "Lindsey Hall",
+        "Bonnie Russell",
+        "Kristin Stewart",
+        "Owen Reid",
+        "Brenda Sherman",
+        "Dwayne Baldwin"
+    ],
+    "bindings": {},
+    "result": [
+        "Felicia Saunders",
+        "Jimmy Schultz",
+        "Dolores Figueroa",
+        "Craig Moreno",
+        "Lindsey Hall",
+        "Bonnie Russell",
+        "Kristin Stewart",
+        "Owen Reid",
+        "Brenda Sherman",
+        "Dwayne Baldwin"
+    ]
+}

--- a/test/test-suite/groups/regex/case038.json
+++ b/test/test-suite/groups/regex/case038.json
@@ -1,0 +1,28 @@
+{
+    "expr": "$map($, function($i){ $match($i, /^(\\w*\\s\\w*)/) }).match",
+    "data": [
+        "Felicia Saunders",
+        "Jimmy Schultz",
+        "Dolores Figueroa",
+        "Craig Moreno",
+        "Lindsey Hall",
+        "Bonnie Russell",
+        "Kristin Stewart",
+        "Owen Reid",
+        "Brenda Sherman",
+        "Dwayne Baldwin"
+    ],
+    "bindings": {},
+    "result": [
+        "Felicia Saunders",
+        "Jimmy Schultz",
+        "Dolores Figueroa",
+        "Craig Moreno",
+        "Lindsey Hall",
+        "Bonnie Russell",
+        "Kristin Stewart",
+        "Owen Reid",
+        "Brenda Sherman",
+        "Dwayne Baldwin"
+    ]
+}


### PR DESCRIPTION
When partially applying the $match function, the regex was compiled and stored in the closure.
The same RegExp object was then applied multiple times in the $map, but the lastIndex property was not being reset, so alternate matches would fail (which then resets lastIndex to 0).

This PR fixes that.

resolves #427 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>