### PR TITLE
unpack outer wrapper in $string()

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -126,6 +126,9 @@ const functions = (() => {
             };
         } else {
             var space = prettify ? 2 : 0;
+            if(Array.isArray(arg) && arg.outerWrapper) {
+                arg = arg[0];
+            }
             str = JSON.stringify(arg, function (key, val) {
                 return (typeof val !== 'undefined' && val !== null && val.toPrecision && isNumeric(val)) ? Number(val.toPrecision(15)) :
                     (val && isFunction(val)) ? '' : val;

--- a/test/test-suite/groups/function-string/case029.json
+++ b/test/test-suite/groups/function-string/case029.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$string()",
+    "data": [4, true],
+    "bindings": {},
+    "result": "[4,true]"
+}


### PR DESCRIPTION
Fixes a regression when the $string() function is applied to a top-level array causing the output to be enclosed in an additional array

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>