### PR TITLE
Fix error in generic matcher example

### DIFF
--- a/docs/regex.md
+++ b/docs/regex.md
@@ -55,9 +55,9 @@ This returns the following JSONata object (JSON, but also with a function proper
 
 ```
 {
-  "match": "plan",
-  "start": 9,
-  "end": 13,
+  "match": "man",
+  "start": 2,
+  "end": 4,
   "groups": [],
   "next": "<native function>#0"
 }


### PR DESCRIPTION
Node.js v14.3.0 was used to verify my change.

    ❯ node
    Welcome to Node.js v14.3.0.
    Type ".help" for more information.
    > const rx = /[a-z]*an[a-z]*/i;
    > const string = 'A man, a plan, a canal, Panama!';
    > string.match(rx);
    [
      'man',
      index: 2,
      input: 'A man, a plan, a canal, Panama!',
      groups: undefined
    ]

In spite of 'i' commonly being used for case insensitive matching, the 'i' modifier is non-performant when matching against large strings. In practice it's better to include both upper and lower cases using standard regular expression class syntax, e.g.: /[a-zA-Z]*[aA][nN][a-zA-Z]*/. This is functionally equivalent to what you currenty have, but it avoids the expensive 'i' modifier.

Consider including an aside to explain this so your readership (who may be unfamiliar with the intracacies of regular expressions) does not blindly accept your use of the 'i' modifier as an exemplar for case-insenstive matching.