### PR TITLE
Further Refine / Simply ExprNode type

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -7,11 +7,12 @@ declare namespace jsonata {
 
   interface ExprNode {
     type: string;
-    value: any;
-    position: number;
-    arguments: {type: string, steps: ExprNode[]}[] | ExprNode[];
+    value?: any;
+    position?: number;
+    arguments?: ExprNode[];
     name?: string;
-    procedure: ExprNode;
+    procedure?: ExprNode;
+    steps?: ExprNode[];
   }
 
   interface JsonataError extends Error {


### PR DESCRIPTION
Rather than the union, just marking fields optional is cleaner as they all share `type`. This reduces the TS error complexity as well. 