### PR TITLE
$eval() - array inputs should be wrapped

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1759,6 +1759,11 @@ var jsonata = (function() {
         var input = this.input;
         if(typeof focus !== 'undefined') {
             input = focus;
+            // if the input is a JSON array, then wrap it in a singleton sequence so it gets treated as a single input
+            if(Array.isArray(input) && !isSequence(input)) {
+                input = createSequence(input);
+                input.outerWrapper = true;
+            }
         }
 
         try {

--- a/test/test-suite/groups/function-eval/case008.json
+++ b/test/test-suite/groups/function-eval/case008.json
@@ -1,0 +1,34 @@
+[
+    {
+        "expr": "$eval(\"{ 'test': 1 }\", [])",
+        "data": {},
+        "bindings": {},
+        "result": {
+            "test": 1
+        }
+    },
+    {
+        "expr": "$eval(\"{ 'test': 1 }\")",
+        "data": [],
+        "bindings": {},
+        "result": {
+            "test": 1
+        }
+    },
+    {
+        "expr": "$eval(\"{ 'test': 1 }\", [1,2,3])",
+        "data": [],
+        "bindings": {},
+        "result": {
+            "test": 1
+        }
+    },
+    {
+        "expr": "$eval(\"{ 'test': 1 }\")",
+        "data": [1,2,3],
+        "bindings": {},
+        "result": {
+            "test": 1
+        }
+    }
+]


### PR DESCRIPTION
The logic for handling the second parameter to this function should be the same as for handling the input to any expression.
This includes wrapping a top level array input in a singleton sequence so it gets treated as a single input.
This code was missing from this function and is added here.

resolves #463 

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>