### PR TITLE
Update copyright date in docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -62,7 +62,7 @@ const siteConfig = {
   */
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
-  copyright: `Copyright © 2018 JSONata.org`,
+  copyright: `Copyright © 2021 JSONata.org`,
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.


### PR DESCRIPTION
For https://github.com/jsonata-js/jsonata/issues/497

Bringing the copyright date up-to-date as per the issue raised.