### PR TITLE
Make boolean operators short-circuit

### DIFF
--- a/test/test-suite/groups/boolean-expresssions/case028.json
+++ b/test/test-suite/groups/boolean-expresssions/case028.json
@@ -1,0 +1,8 @@
+{
+    "description": "will not evaluate rhs (which would error) because lhs is true",
+    "expr": "foo = '' or $number(foo) = 0",
+    "data": {
+        "foo":""
+    },
+    "result": true
+}

--- a/test/test-suite/groups/boolean-expresssions/case029.json
+++ b/test/test-suite/groups/boolean-expresssions/case029.json
@@ -1,0 +1,8 @@
+{
+    "description": "will not evaluate rhs (which would error) because lhs is false",
+    "expr": "$type(data) = 'number' and data > 10",
+    "data": {
+        "data":"15"
+    },
+    "result": false
+}

--- a/test/test-suite/groups/boolean-expresssions/case030.json
+++ b/test/test-suite/groups/boolean-expresssions/case030.json
@@ -1,0 +1,8 @@
+{
+    "description": "throws error on right side of boolean expression (for CC of a catch)",
+    "expr": "$type(age) = 'number' or $number(age) > 0",
+    "data": {
+        "age":"33 1/2"
+    },
+    "code": "D3030"
+}


### PR DESCRIPTION
My first ever PR to an open-source project. Woo!

Fixes #338 and #505.

Defers execution of the right-hand side of boolean expressions. Uses the natural short-circuiting behavior of Javascript's `||` and `&&` operators to evaluate only when needed.