### PR TITLE
Add missing properties to ExprNode type definition

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -13,6 +13,10 @@ declare namespace jsonata {
     name?: string;
     procedure?: ExprNode;
     steps?: ExprNode[];
+    expressions?: ExprNode[];
+    stages?: ExprNode[];
+    lhs?: ExprNode;
+    rhs?: ExprNode;
   }
 
   interface JsonataError extends Error {


### PR DESCRIPTION
While working with the library I encountered the following missing properties from the ExprNode type definition.
* `expressions` exists when type is `block`
* `lhs` and `rhs` exist when type is `binary`