### PR TITLE
fix regression with singleton sequence of array type

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -219,7 +219,8 @@ var jsonata = (function() {
         }
 
         if(expr.keepSingletonArray) {
-            if(!isSequence(resultSequence)) {
+            // if the array is explicitly constructed in the expression and marked to promote singleton sequences to array
+            if(Array.isArray(resultSequence) && resultSequence.cons && !resultSequence.sequence) {
                 resultSequence = createSequence(resultSequence);
             }
             resultSequence.keepSingleton = true;

--- a/test/test-suite/groups/array-constructor/array-sequences.json
+++ b/test/test-suite/groups/array-constructor/array-sequences.json
@@ -1,0 +1,68 @@
+[
+    {
+        "expr": "$.[value,epochSeconds][]",
+        "data": [
+            {
+                "epochSeconds": 1578381600,
+                "value": 3
+            },
+            {
+                "epochSeconds": 1578381700,
+                "value": 5
+            }
+        ],
+        "bindings": {},
+        "result": [
+            [3, 1578381600],
+            [5, 1578381700]
+        ]
+    },
+    {
+        "expr": "$.[value,epochSeconds][]",
+        "data": [
+            {
+                "epochSeconds": 1578381600,
+                "value": 3
+            }
+        ],
+        "bindings": {},
+        "result": [
+            [3, 1578381600]
+        ]
+    },
+    {
+        "expr": "$.[value,epochSeconds]",
+        "data": [
+            {
+                "epochSeconds": 1578381600,
+                "value": 3
+            }
+        ],
+        "bindings": {},
+        "result": [3, 1578381600]
+    },
+    {
+        "expr": "singleArray",
+        "data": {
+            "singleArray": [{"foo":"bar"}]
+        },
+        "bindings": {},
+        "result": [
+            {
+                "foo": "bar"
+            }
+        ]
+    },
+    {
+        "expr": "singleArray[]",
+        "data": {
+            "singleArray": [{"foo":"bar"}]
+        },
+        "bindings": {},
+        "result": [
+            {
+                "foo": "bar"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Change the logic for promoting a singleton sequence of array type into an array of arrays.  The logic was put in to fix issue #399 but caused an unintended regression as described in issue #462.

resolves #462

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>