### PR TITLE
Update nodejs versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+- '16'
+- '14'
 - '12'
-- '10'
-- '8'
 after_success:
 - npm run coveralls
 jobs:
@@ -17,7 +17,7 @@ jobs:
     - cd website && npm install && GIT_USER="${GH_NAME}" npm run publish-gh-pages
   - stage: npm release
     if: branch = master AND repo = jsonata-js/jsonata
-    node_js: '10'
+    node_js: '14'
     script: echo "Deploying to npm..."
     deploy:
       provider: npm


### PR DESCRIPTION
Spotted in the recent Travis runs that it was testing with versions 8, 10 and 12; 8 went out of support in April 2020, and 10 in April 2021, and so can be dropped from support (or at least from active testing). Things like node-red also require 12, as has become quite common across a lot of packages.

So switching this to go with:
- 12 (Maintenance LTS)
- 14 (Active LTS)
- 16 (Current major version, next LTS in October)

@andrew-coleman Arguably this should be a major version bump, as dropping Node.js version support is a breaking change (it's something I've seen seen quite a few packages on npm do, and we're also doing internally). However, I think we might want a discussion on versioning rather than doing that right now with this.