### PR TITLE
toMillis: Allow width formatting without separators

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -983,6 +983,7 @@ const dateTime = (function () {
                         return offsetHours * 60 + offsetMinutes;
                     };
                 } else if (part.integerFormat) {
+                    part.integerFormat.n = part.n;
                     res = generateRegex(part.integerFormat);
                 } else {
                     // must be a month or day name
@@ -1030,7 +1031,11 @@ const dateTime = (function () {
             // Note, syntax based on https://www.w3.org/TR/xpath-functions-31/#date-time-examples
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
-            const occurrences = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? `{${formatSpec.mandatoryDigits}}` : '+';
+            // const mandatoryDigits = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? formatSpec.mandatoryDigits : 0;
+            // const optionalDigits = formatSpec.optionalDigits && formatSpec.optionalDigits > 0 ? formatSpec.optionalDigits : 0;
+            // const totalDigits = mandatoryDigits + optionalDigits;
+            // eslint-disable-next-line no-unused-vars
+            const occurrences = formatSpec.n && formatSpec.n > 1 ? `{${formatSpec.n}}` : '+';
             switch (formatSpec.primary) {
                 case formats.LETTERS:
                     matcher.regex = isUpper ? '[A-Z]+' : '[a-z]+';

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1030,7 +1030,7 @@ const dateTime = (function () {
             // Note, syntax based on https://www.w3.org/TR/xpath-functions-31/#date-time-examples
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
-            const mandatoryDigits = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? formatSpec.mandatoryDigits.toString() : '+';
+            const occurrences = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? `{${formatSpec.mandatoryDigits}}` : '+';
             switch (formatSpec.primary) {
                 case formats.LETTERS:
                     matcher.regex = isUpper ? '[A-Z]+' : '[a-z]+';
@@ -1051,7 +1051,7 @@ const dateTime = (function () {
                     };
                     break;
                 case formats.DECIMAL:
-                    matcher.regex = `[0-9]{${mandatoryDigits}}`;
+                    matcher.regex = `[0-9]${occurrences}`;
                     if (formatSpec.ordinal) {
                         // ordinals
                         matcher.regex += '(?:th|st|nd|rd)';

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1025,8 +1025,12 @@ const dateTime = (function () {
                 return res;
             });
         } else { // type === 'integer'
+            // MYTODO
+            // It seems that _formatInteger accounts for mandatoryDigits but here it does not
+            // Note, syntax based on https://www.w3.org/TR/xpath-functions-31/#date-time-examples
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
+            const mandatoryDigits = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? formatSpec.mandatoryDigits.toString() : '+';
             switch (formatSpec.primary) {
                 case formats.LETTERS:
                     matcher.regex = isUpper ? '[A-Z]+' : '[a-z]+';
@@ -1047,7 +1051,7 @@ const dateTime = (function () {
                     };
                     break;
                 case formats.DECIMAL:
-                    matcher.regex = '[0-9]+';
+                    matcher.regex = `[0-9]{${mandatoryDigits}}`;
                     if (formatSpec.ordinal) {
                         // ordinals
                         matcher.regex += '(?:th|st|nd|rd)';

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -612,7 +612,7 @@ const dateTime = (function () {
                             def.integerFormat.mandatoryDigits = def.width.min;
                         }
                     }
-                    if (def.component === 'Y') {
+                    if ('YMD'.indexOf(def.component) !== -1) {
                         // §9.8.4.4
                         def.n = -1;
                         if (def.width && def.width.max !== undefined) {

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1028,7 +1028,17 @@ const dateTime = (function () {
         } else { // type === 'integer'
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
-            const occurrences = formatSpec.n && formatSpec.n > 0 ? `{${formatSpec.n}}` : '+';
+            let occurrences;
+            if(formatSpec.n && formatSpec.n > 0){
+                if(formatSpec.optionalDigits === 0){
+                    occurrences = `{${formatSpec.n}}`;
+                } else {
+                    occurrences = `{${formatSpec.n - formatSpec.optionalDigits},${formatSpec.n}}`;
+                }
+            } else {
+                occurrences = '+';
+            }
+
             switch (formatSpec.primary) {
                 case formats.LETTERS:
                     matcher.regex = isUpper ? '[A-Z]+' : '[a-z]+';

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1028,7 +1028,7 @@ const dateTime = (function () {
         } else { // type === 'integer'
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
-            const occurrences = formatSpec.n && formatSpec.n > 1 ? `{${formatSpec.n}}` : '+';
+            const occurrences = formatSpec.n && formatSpec.n > 0 ? `{${formatSpec.n}}` : '+';
             switch (formatSpec.primary) {
                 case formats.LETTERS:
                     matcher.regex = isUpper ? '[A-Z]+' : '[a-z]+';

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1026,15 +1026,8 @@ const dateTime = (function () {
                 return res;
             });
         } else { // type === 'integer'
-            // MYTODO
-            // It seems that _formatInteger accounts for mandatoryDigits but here it does not
-            // Note, syntax based on https://www.w3.org/TR/xpath-functions-31/#date-time-examples
             matcher.type = 'integer';
             const isUpper = formatSpec.case === tcase.UPPER;
-            // const mandatoryDigits = formatSpec.mandatoryDigits && formatSpec.mandatoryDigits > 0 ? formatSpec.mandatoryDigits : 0;
-            // const optionalDigits = formatSpec.optionalDigits && formatSpec.optionalDigits > 0 ? formatSpec.optionalDigits : 0;
-            // const totalDigits = mandatoryDigits + optionalDigits;
-            // eslint-disable-next-line no-unused-vars
             const occurrences = formatSpec.n && formatSpec.n > 1 ? `{${formatSpec.n}}` : '+';
             switch (formatSpec.primary) {
                 case formats.LETTERS:

--- a/test/test-suite/groups/function-tomillis/case010.json
+++ b/test/test-suite/groups/function-tomillis/case010.json
@@ -1,5 +1,5 @@
 {
-    "expr": "$toMillis(\"201802\", \"[Y1111][M11]\")",
+    "expr": "$toMillis(\"201802\", \"[Y0001][M01]\")",
     "dataset": "dataset5",
     "bindings": {},
     "result": 1517443200000

--- a/test/test-suite/groups/function-tomillis/case010.json
+++ b/test/test-suite/groups/function-tomillis/case010.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$toMillis(\"201802\", \"[Y1111][M11]\")",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": 1517443200000
+}

--- a/test/test-suite/groups/function-tomillis/case011.json
+++ b/test/test-suite/groups/function-tomillis/case011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$toMillis(\"201802\", \"[Y,*-4][M01]\")",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": 1517443200000
+}

--- a/test/test-suite/groups/function-tomillis/case012.json
+++ b/test/test-suite/groups/function-tomillis/case012.json
@@ -2,5 +2,5 @@
     "expr": "$toMillis(\"20180205\", \"[Y0001][M01][D01]\")",
     "dataset": "dataset5",
     "bindings": {},
-    "result": 1520208000000
+    "result": 1517788800000
 }

--- a/test/test-suite/groups/function-tomillis/case012.json
+++ b/test/test-suite/groups/function-tomillis/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$toMillis(\"20180205\", \"[Y0001][M01][D01]\")",
+    "dataset": "dataset5",
+    "bindings": {},
+    "result": 1520208000000
+}


### PR DESCRIPTION
# Bug Summary

Width formatting doesn't appear to be respected without a separator. Corresponding issue: https://github.com/jsonata-js/jsonata/issues/546

# Versions

JSONata `1.8.5`
Node `v14.17.0`

# Detailed Information

Reference spec for width formatting: https://www.w3.org/TR/xpath-functions-31/#date-time-examples

At the moment, it appears the width formatting is not honored within `$toMillis` due to the way the regex is being generated. For an example input `201802`, I should be able to specify a matcher `[Y0001][M01]` which will result in a parsed value of `2018/02/01`. At the moment, the library incorrectly grabs too many characters due to the `+` regex so I end up with `20180/02/01`


## Test Cases

| Input | Picture | Output (timestamp) | Output (pretty) |
| --- | --- | --- | --- |
| 201802 | `[Y0001][M01]` | 1517443200000 | Thu, 01 Feb 2018 00:00:00 GMT |
| 201802 | `[Y,*-4][M01]` | 1517443200000 | Thu, 01 Feb 2018 00:00:00 GMT |
| 20180205 | `[Y0001][M01][D01]]` | 1517788800000 | Mon, 05 Feb 2018 00:00:00 GMT |