### PR TITLE
Remove dead tech talk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ In a browser:
 - JSONata [documentation](http://docs.jsonata.org/)
 - [JavaScript API](http://docs.jsonata.org/embedding-extending)
 - [Intro talk](https://www.youtube.com/watch?v=TDWf6R8aqDo) at London Node User Group
-- JSONata [tech talk](https://www.youtube.com/watch?v=ZRtlkIj0uDY) 
 
 ## Contributing
 


### PR DESCRIPTION
Originally opened as a test that Travis triggers, but actually probably worth removing this dead link to a now-removed YouTube video from the readme