### PR TITLE
Fix error position property for errors in functions

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1412,7 +1412,7 @@ var jsonata = (function() {
             throw {
                 code: "T1005",
                 stack: (new Error()).stack,
-                position: expr.position,
+                position: expr.position - 1,
                 token: expr.procedure.steps[0].value
             };
         }
@@ -1447,7 +1447,7 @@ var jsonata = (function() {
         } catch (err) {
             if(!err.position) {
                 // add the position field to the error
-                err.position = expr.position;
+                err.position = expr.position - 1;
             }
             if (!err.token) {
                 // and the function identifier
@@ -1539,7 +1539,7 @@ var jsonata = (function() {
                 if (typeof err.token == 'undefined' && typeof proc.token !== 'undefined') {
                     err.token = proc.token;
                 }
-                err.position = proc.position;
+                err.position = proc.position - 1;
             }
             throw err;
         }

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -347,7 +347,7 @@ describe("Tests that bind Javascript functions", () => {
                 expr.evaluate({});
             })
                 .to.throw(DOMException)
-                .to.deep.contain({ message: 'Here is my message', position: 12, token: 'throwDomEx' });
+                .to.deep.contain({ message: 'Here is my message', position: 11, token: 'throwDomEx' });
         });
     });
 
@@ -557,7 +557,7 @@ describe("Tests that bind Javascript functions", () => {
             var result = expr.evaluate();
             var expected = [true, false];
             expect(result).to.deep.equal(expected);
-        })
+        });
 
     });
 });
@@ -736,7 +736,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "D3040", token: "match", index: 3, value: -3 });
+                    .to.deep.contain({ position: 6, code: "D3040", token: "match", index: 3, value: -3 });
             });
         });
 
@@ -747,7 +747,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 3, value: null });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 3, value: null });
             });
         });
 
@@ -758,7 +758,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 3, value: "2" });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 3, value: "2" });
             });
         });
 
@@ -769,7 +769,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 2, value: "ab" });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 2, value: "ab" });
             });
         });
 
@@ -780,7 +780,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 2, value: true });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 2, value: true });
             });
         });
 
@@ -791,7 +791,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 1, value: 12345 });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 1, value: 12345 });
             });
         });
 
@@ -802,7 +802,7 @@ describe("Tests that are specific to a Javascript runtime", () => {
                     expr.evaluate();
                 })
                     .to.throw()
-                    .to.deep.contain({ position: 7, code: "T0410", token: "match", index: 1 });
+                    .to.deep.contain({ position: 6, code: "T0410", token: "match", index: 1 });
             });
         });
     });
@@ -829,7 +829,7 @@ describe("Tests that include infinite recursion", () => {
                 expr.evaluate();
             })
                 .to.throw()
-                .to.deep.contain({ token: "inf", position: 32, code: "U1001" });
+                .to.deep.contain({ token: "inf", position: 31, code: "U1001" });
         });
     });
 


### PR DESCRIPTION
While playing with the JSONata exerciser, I've noticed that the `position` property gets set correctly for all of the errors I was able to reproduce, except for everything related to calling functions, see a couple of examples below.

looks good:

<img width="189" alt="image" src="https://user-images.githubusercontent.com/1835550/162944257-4ab7ba0e-7447-402f-9f13-7aa11839a897.png">

looks not good:

<img width="441" alt="image" src="https://user-images.githubusercontent.com/1835550/162944237-c651e28f-3518-4b2b-b249-6d2bc441fd1b.png">
<img width="128" alt="image" src="https://user-images.githubusercontent.com/1835550/162944247-85d97ec0-033e-4382-8f57-dbb7ca4725a8.png">

It seems like due to how JSONata evaluates functions, the position is already moved by 1 to the opening bracket character, which messes up the error highlighting, as the `error.token` does not include the opening `(` character, but the position is already past it.

IMHO, it would be better if JSONata was reducing the position by 1 to match the reported token. 

This PR is aiming to implement this adjusted behavior, but if there's a better way to solve this problem - I'm open to feedback!