### PR TITLE
Test on Node.js 18

### DIFF
--- a/.github/workflows/jsonata.yml
+++ b/.github/workflows/jsonata.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install and build
         run: npm install && npm test
       - name: Publish to NPM
@@ -47,10 +47,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Build documentation
         run: |
           cd website


### PR DESCRIPTION
Node.js 18.x is now the current LTS version and so should be the one most people are now running or moving to, so we should run the tests against it to support it.

Would have been good to stop 12.x, as it's been out of support for a while, but that's best done on a major version bump and I just missed the boat on that one! Can remove 12 and 14 together when 14 goes out of support in April for 3.0.0.