### PR TITLE
added default (elvis) operator

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -482,6 +482,9 @@ var jsonata = (function() {
                 case '>=':
                     result = evaluateComparisonExpression(lhs, rhs, op);
                     break;
+                case '?:':
+                    result = evaluateDefault(lhs, rhs, op);
+                    break;                    
                 case '&':
                     result = evaluateStringConcat(lhs, rhs);
                     break;
@@ -808,6 +811,16 @@ var jsonata = (function() {
                 break;
         }
         return result;
+    }
+
+    /**
+     * Evaluate default-value expression
+     * @param {Object} lhs - LHS value
+     * @param {Object} rhs - RHS value
+     * @returns {*} Result
+     */
+    function evaluateDefault(lhs, rhs) {
+        return lhs ? lhs : rhs;
     }
 
     /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -40,6 +40,7 @@ const parser = (() => {
         '<=': 40,
         '>=': 40,
         '~>': 40,
+        '?:': 40,
         'and': 30,
         'or': 25,
         'in': 40,
@@ -197,6 +198,11 @@ const parser = (() => {
                 // ~>  chain function
                 position += 2;
                 return create('operator', '~>');
+            }
+            if (currentChar === '?' && path.charAt(position + 1) === ':') {
+                // ?: default / elvis operator
+                position += 2;
+                return create('operator', '?:');
             }
             // test for single char operators
             if (Object.prototype.hasOwnProperty.call(operators, currentChar)) {
@@ -565,6 +571,7 @@ const parser = (() => {
         terminal("in"); //
         prefix("-"); // unary numeric negation
         infix("~>"); // function application
+        infix("?:"); // default value
 
         infixr("(error)", 10, function (left) {
             this.lhs = left;

--- a/test/test-suite/groups/default-operator/case000.json
+++ b/test/test-suite/groups/default-operator/case000.json
@@ -1,0 +1,7 @@
+{
+    "description": "property missing on object uses default string on lhs",
+    "expr": "order?:'the usual'",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": "the usual"
+}

--- a/test/test-suite/groups/default-operator/case001.json
+++ b/test/test-suite/groups/default-operator/case001.json
@@ -1,0 +1,7 @@
+{
+    "description": "property missing on object uses default number on lhs",
+    "expr": "age?:42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case003.json
+++ b/test/test-suite/groups/default-operator/case003.json
@@ -1,0 +1,7 @@
+{
+    "description": "property present on object is used",
+    "expr": "bar ?: 0",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 98
+}

--- a/test/test-suite/groups/default-operator/case004.json
+++ b/test/test-suite/groups/default-operator/case004.json
@@ -1,0 +1,7 @@
+{
+    "description": "operator can be chained",
+    "expr": "nope ?: foo.bar ?: 0",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}


### PR DESCRIPTION
Implements request from #370.

I have never been sure about how the project owners feel about the addition of operators. Functions are one thing, but an operator is a first-class citizen, and eating one up has roadmap-altering consequences. Is there even a roadmap?

Of all the proposed syntaxes, I opted to use the elvis operator `?:` since it's so close to its functional equivalent.
`property ? property : 'default'` becomes `property ?: 'default'`. (Just collapse the `?` and the `:` of a ternary.)

Draft mode for now since:
- I want to get general input about the direction and use of a new operator
- Right now the implementation is pure javascript by using the javascript ternary, which may have different rules for what is "truthy" than the JSONata ternary. I suspect this should change to match JSONata's ternary logic.
- I'm wondering if this operator should be a short-circuiting operator to prevent the overhead of the evaluation of a potentially expensive RHS that won't be used. Thoughts?
- Documentation needs to be updated.

Thanks for looking!