### PR TITLE
Add upper/lower presentation format for am/pm in fromMillis

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -904,6 +904,13 @@ const dateTime = (function () {
                 if (offset === 0 && markerSpec.presentation2 === 't') {
                     componentValue = 'Z';
                 }
+            } else if (markerSpec.component === 'P') {
+                // §9.8.4.7 Formatting Other Components
+                // Formatting P for am/pm
+                // getDateTimeFragment() always returns am/pm lower case so check for UPPER here
+                if (markerSpec.names === tcase.UPPER) {
+                    componentValue = componentValue.toUpperCase();
+                }
             }
             return componentValue;
         };

--- a/test/test-suite/groups/function-fromMillis/formatDateTime.json
+++ b/test/test-suite/groups/function-fromMillis/formatDateTime.json
@@ -541,6 +541,22 @@
     },
     {
         "function": "#fromMillis",
+        "category": "Upper case AM/PM presentation",
+        "description": "am/pm presentation should be set to uppercase AM",
+        "expr": "$fromMillis(1521801216617, '[F], [D]/[M]/[Y] [h]:[m]:[s] [PN]')",
+        "data": {},
+        "result": "friday, 23/3/2018 10:33:36 AM"
+    },
+    {
+        "function": "#fromMillis",
+        "category": "Lower case AM/PM presentation",
+        "description": "am/pm presentation should be set to lowercase am",
+        "expr": "$fromMillis(1521801216617, '[F], [D]/[M]/[Y] [h]:[m]:[s] [Pn]')",
+        "data": {},
+        "result": "friday, 23/3/2018 10:33:36 am"
+    },
+    {
+        "function": "#fromMillis",
         "category": "error",
         "description": "throws error asking for year name",
         "expr": "$fromMillis(1419940800000, '[YN]-[M]-[D]')",


### PR DESCRIPTION
Fixes #574

Updates [$fromMillis() function](https://docs.jsonata.org/date-time-functions#frommillis) to support am/pm `PN` presentation format to output AM/PM and adds test cases for `PN` and `Pn` (existing test case for default presentation covers just `P`).

Note: I did not implement [PNn] for Am/Pm, it's not shown in the examples https://www.w3.org/TR/xpath-functions-31/#date-time-examples so I assumed it's not commonly used and did not implement it to keep the fix simple. Happy to revisit that if needed.

Signed-off-by: Alex Woodgate <ajwoodgate@gmail.com>