### PR TITLE
Update workflow for Node.js 20

### DIFF
--- a/.github/workflows/jsonata.yml
+++ b/.github/workflows/jsonata.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Also run testing on Node.js 20.x as the current LTS version.

12, 14 and 16 are out of support (18 keeps going for another year) so might want to consider dropping them at some point, but that should be done as part of a major version bump.