### PR TITLE
Repair bad logic around `undefined != <anything-else>`

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -736,11 +736,6 @@ var jsonata = (function() {
         var ltype = typeof lhs;
         var rtype = typeof rhs;
 
-        if (ltype === 'undefined' || rtype === 'undefined') {
-            // if either side is undefined, the result is false
-            return false;
-        }
-
         switch (op) {
             case '=':
                 result = isDeepEqual(lhs, rhs);


### PR DESCRIPTION
`undefined != "foo"` should evaluate to `true`