### PR TITLE
Prevent lookup of function object properties

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1658,7 +1658,7 @@ const functions = (() => {
                 });
             });
             result = keys(merge);
-        } else if (arg !== null && typeof arg === 'object' && !(isLambda(arg))) {
+        } else if (arg !== null && typeof arg === 'object' && !isFunction(arg)) {
             Object.keys(arg).forEach(key => result.push(key));
         }
         return result;
@@ -1685,7 +1685,7 @@ const functions = (() => {
                     }
                 }
             }
-        } else if (input !== null && typeof input === 'object') {
+        } else if (input !== null && typeof input === 'object' && !isFunction(input)) {
             result = input[key];
         }
         return result;

--- a/test/test-suite/groups/lambdas/case013.json
+++ b/test/test-suite/groups/lambdas/case013.json
@@ -1,0 +1,6 @@
+{
+    "expr": "( $f := function(){1}; $f.environment )",
+    "dataset": null,
+    "bindings": {},
+    "undefinedResult": true
+}


### PR DESCRIPTION
A lambda function is represented internally as a javascript object.  A check needs to be added to the `lookup` function to only expose properties if they are a non-function object.  Similar to the check that already exists in the `keys` function.

Resolves #691 