### PR TITLE
Protect `__evaluate_entry` and `__evaluate_exit` callbacks

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -31,8 +31,8 @@ declare namespace jsonata {
   }
 
   interface Environment {
-    bind(name: string, value: any): void;
-    lookup(name: string): any;
+    bind(name: string | symbol, value: any): void;
+    lookup(name: string | symbol): any;
     readonly timestamp: Date;
     readonly async: boolean;
   }

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -50,7 +50,7 @@ var jsonata = (function() {
     async function evaluate(expr, input, environment) {
         var result;
 
-        var entryCallback = environment.lookup('__evaluate_entry');
+        var entryCallback = environment.lookup(Symbol.for('jsonata.__evaluate_entry'));
         if(entryCallback) {
             await entryCallback(expr, input, environment);
         }
@@ -124,7 +124,7 @@ var jsonata = (function() {
             result = await evaluateGroupExpression(expr.group, result, environment);
         }
 
-        var exitCallback = environment.lookup('__evaluate_exit');
+        var exitCallback = environment.lookup(Symbol.for('jsonata.__evaluate_exit'));
         if(exitCallback) {
             await exitCallback(expr, input, environment, result);
         }

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -1057,11 +1057,11 @@ function timeboxExpression(expr, timeout, maxDepth) {
     };
 
     // register callbacks
-    expr.assign("__evaluate_entry", function() {
+    expr.assign(Symbol.for('jsonata.__evaluate_entry'), function() {
         depth++;
         checkRunnaway();
     });
-    expr.assign("__evaluate_exit", function() {
+    expr.assign(Symbol.for('jsonata.__evaluate_exit'), function() {
         depth--;
         checkRunnaway();
     });

--- a/test/run-test-suite.js
+++ b/test/run-test-suite.js
@@ -178,12 +178,12 @@ function timeboxExpression(expr, timeout, maxDepth) {
     };
 
     // register callbacks
-    expr.assign("__evaluate_entry", function(expr, input, env) {
+    expr.assign(Symbol.for('jsonata.__evaluate_entry'), function(expr, input, env) {
         if (env.isParallelCall) return;
         depth++;
         checkRunnaway();
     });
-    expr.assign("__evaluate_exit", function(expr, input, env) {
+    expr.assign(Symbol.for('jsonata.__evaluate_exit'), function(expr, input, env) {
         if (env.isParallelCall) return;
         depth--;
         checkRunnaway();


### PR DESCRIPTION
Fixes https://github.com/jsonata-js/jsonata/issues/695

These two internal/undocumented APIs are very useful in debugging scenarios and for imposing time/depth constraints on queries. However, this internal API should only be accessible when configuring an expression programmatically and not from inside a query. Otherwise, a query can be manipulated to remove such diagnostics or constraints. Addressing this could potentially protect consumers with certain use cases from targeted attacks.

By changing both binding keys to `Symbol`, they can no longer be accessed inside of the query since the Symbol API is not accessible there. Without access to the Symbol, a query is fundamentally unable to address these bindings.

I am building a pluggable and security-minded framework around JSONata (open source), which makes considerable use of these properties, and I want to protect them. But this is generally applicable. Many people processing queries on the server will not want a query to be able to remove these hooks.

At first, I considered increasing the API surface to do this, but then I realized that using `Symbol.for` is a super pragmatic and ergonomic way of solving this problem with minimal changes, which makes sense for something internal like this. Symbols' primary use case is implementing this kind of separation between public and internal naming, so I think this is the way to go.

Attempting to manipulate the old properties inside a query as described in https://github.com/jsonata-js/jsonata/issues/695 is now not possible. There's nothing special anymore about those references, and they work like any other reference.

I have also made the corresponding change to https://github.com/jsonata-js/jsonata-exerciser/pull/36.

I'm pinging @andrew-coleman as this is something we previously discussed over email. Also, see https://github.com/jsonata-js/jsonata/pull/701. These two small changes will unlock a whole realm of possibilities and allow me to do it safely and securely.

Signed-off-by: Adam Thomas <adam@adam-thomas.co.uk>