### PR TITLE
Add undocumented/private API to hook into when a new frame is created.

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1837,7 +1837,7 @@ var jsonata = (function() {
      */
     function createFrame(enclosingEnvironment) {
         var bindings = {};
-        return {
+        const newFrame = {
             bind: function (name, value) {
                 bindings[name] = value;
             },
@@ -1857,6 +1857,16 @@ var jsonata = (function() {
                 ancestry: [ null ]
             }
         };
+
+        if (enclosingEnvironment) {
+            var framePushCallback = enclosingEnvironment.lookup(Symbol.for('jsonata.__createFrame_push'));
+            if(framePushCallback) {
+                framePushCallback(enclosingEnvironment, newFrame);
+            }
+        }
+       
+
+        return newFrame
     }
 
     // Function registration

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -1024,6 +1024,21 @@ describe("Tests that include infinite recursion", () => {
     });
 });
 
+describe("Tests that use internal frame push callbacks", () => {
+    describe("frame push callback bound to expression", function()  {
+        it("calls callback when new frame created", function(done) {
+            var expr = jsonata("( )");
+            expr.assign(Symbol.for('jsonata.__createFrame_push'), function(parentEnv, newEnv) {
+                expect(parentEnv).to.not.equal(newEnv);
+                expect(parentEnv).to.include.keys(['lookup', 'bind']);
+                expect(newEnv).to.include.keys(['lookup', 'bind']);
+                done();
+            });
+            expr.evaluate();
+        });
+    });
+});
+
 /**
  * Protect the process/browser from a runnaway expression
  * i.e. Infinite loop (tail recursion), or excessive stack growth


### PR DESCRIPTION
This is a small change to add a new hook, similar to `__evaluate_entry` and `__evaluate_exit`, but for when a new frame is created from an old one. I am building an open-source pluggable framework around JSonata, and this small change will open up an enormous amount of awesome possibilities.

It is beneficial for advanced cases like modifying env with additional metadata or mutating it so that you can analyse bind/lookup calls & provide diagnostics. I have actually _patially_ achieved this already to significant effect by hooking into the env on `__evaluate_entry`. However, in some cases inside the JSONata core, a new frame is created, which is then immediately bound to, and consequently that happens before it has yet to recurse through `evaluate` and the entry callback. That means that callback is unable to capture everything for these advance pro-mode use cases. This new callback would enable that possibility.

I accept this will be undocumented and could change in the future.

The callback is set via a `Symbol`, so it can not be manipulated or read inside a query. See #700, which would need to be merged first, both as approval of the general `Symbol` approach and because the minor TS def changes are needed from there.

Signed-off-by: Adam Thomas [adam@adam-thomas.co.uk](mailto:adam@adam-thomas.co.uk)