### PR TITLE
Update interface

### DIFF
--- a/jsonata.d.ts
+++ b/jsonata.d.ts
@@ -20,7 +20,7 @@ declare namespace jsonata {
     steps?: ExprNode[];
     expressions?: ExprNode[];
     stages?: ExprNode[];
-    lhs?: ExprNode[];
+    lhs?: ExprNode | ExprNode[];
     rhs?: ExprNode;
   }
 


### PR DESCRIPTION
Update interface property ExprNode.lhs to be either an ExprNode or ExprNode[] as described in issue [#703](https://github.com/jsonata-js/jsonata/issues/703)

For example, jsonata('($x := 1; $y := 2;)').ast().expressions outputs an object as the value for `lhs`.

```javascript
[
  {
    type: "bind",
    value: ":=",
    position: 7,
    lhs: { value: "x", type: "variable", position: 4 },
    rhs: { value: 1, type: "number", position: 9 },
  },
  {
    type: "bind",
    value: ":=",
    position: 15,
    lhs: { value: "y", type: "variable", position: 13 },
    rhs: { value: 2, type: "number", position: 16 },
  },
];
```


And jsonata('{"x": y, "z": 1}').ast() outputs an array as the value for `lhs`.

```javascript
{
      "type": "unary",
      "value": "{",
      "position": 1,
      "lhs": [
        [
          {
            "value": "x",
            "type": "string",
            "position": 4
          },
          {
            "type": "path",
            "steps": [
              {
                "value": "y",
                "type": "name",
                "position": 7
              }
            ]
          }
        ],
        [
          {
            "value": "z",
            "type": "string",
            "position": 12
          },
          {
            "value": 1,
            "type": "number",
            "position": 15
          }
        ]
      ]
    }
```

Similar issue: https://github.com/jsonata-js/jsonata/issues/585

I've also added all the possible string types for ExprNode.type

Signed-off-by: Vlad Dimov <devdimov@proton.me>