### PR TITLE
Chain operator should respect array constructor

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1194,6 +1194,7 @@ const parser = (() => {
                             result = {type: 'apply', value: expr.value, position: expr.position};
                             result.lhs = processAST(expr.lhs);
                             result.rhs = processAST(expr.rhs);
+                            result.keepArray = result.lhs.keepArray || result.rhs.keepArray;
                             break;
                         default:
                             result = {type: expr.type, value: expr.value, position: expr.position};

--- a/test/test-suite/groups/hof-map/case0010.json
+++ b/test/test-suite/groups/hof-map/case0010.json
@@ -1,0 +1,6 @@
+{
+    "expr": "( $square := function($x){$x*$x}; $map([1], $square)[] )",
+    "data": null,
+    "bindings": {},
+    "result": [1]
+}

--- a/test/test-suite/groups/hof-map/case0011.json
+++ b/test/test-suite/groups/hof-map/case0011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "( $data := [1]; $square := function($x){$x*$x}; $data ~> $map($square)[] )",
+    "data": null,
+    "bindings": {},
+    "result": [1]
+}


### PR DESCRIPTION
This PR fixes the problem where when using a HOF like map with a chain operator, the array constructor is not respected which is added to enforce that the output is always an array regardless of the input.

Take this example:

```
$map([1], function($v){$v*$v})[]
```

returns correctly `[1]`. However, when using a chain operator like that:

```
$ ~> $map(function($v){$v*$v})[]
```

and providing `[1]` as input, the singleton value is returned.
This PR fixes that and adds 2 test cases to the test suite.