### PR TITLE
Run tests on Node.js 22

### DIFF
--- a/.github/workflows/jsonata.yml
+++ b/.github/workflows/jsonata.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Install and build
         run: npm install && npm test
       - name: Publish to NPM
@@ -47,10 +47,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Build documentation
         run: |
           cd website


### PR DESCRIPTION
Node.js 22 is now the active LTS version, so GitHub actions testing should be running on 22 as well as other versions. As the active LTS it probably makes sense to run the other actions on this version too.

At some point we may drop 12, 14 and 16 as they are out of support (and 18 too after April next year), but as they're still passing we can leave them for now. Dropping any of these versions should result in a major version bump.