### PR TITLE
Improve regex generation for DateTime parser

### DIFF
--- a/test/test-suite/groups/function-tomillis/case013.json
+++ b/test/test-suite/groups/function-tomillis/case013.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$toMillis('2024-01-01T12:38:49Z') = $toMillis('20240101123849', '[Y0000][M00][D00][H00][m00][s00]')",
+    "data": null,
+    "bindings": {},
+    "result": true
+}


### PR DESCRIPTION
If there are two adjacent integer definitions for date/time fields in the picture string without any extra markup between them, then the generated regex must precisely define the number of digits in the first field.

Resolves #727 