### PR TITLE
$pad function to truncate fractional part of numeric argument

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -293,6 +293,7 @@ const functions = (() => {
         }
 
         var result;
+        width = Math.trunc(width);
         var padLength = Math.abs(width) - length(str);
         if (padLength > 0) {
             var padding = (new Array(padLength + 1)).join(char);

--- a/test/test-suite/groups/function-pad/case011.json
+++ b/test/test-suite/groups/function-pad/case011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$pad('foo', 5.7, ' ')",
+    "dataset": null,
+    "bindings": {},
+    "result": "foo  "
+}

--- a/test/test-suite/groups/function-pad/case012.json
+++ b/test/test-suite/groups/function-pad/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$pad('foo', -5.7, ' ')",
+    "dataset": null,
+    "bindings": {},
+    "result": "  foo"
+}


### PR DESCRIPTION
Truncating the fractional part of the argument is consistent with the behaviour of other functions expecting integer arguments (e.g. substring)

Resolves #717 