### PR TITLE
Add support of shorthand property syntax

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -759,9 +759,18 @@ const parser = (() => {
             if (node.id !== "}") {
                 for (; ;) {
                     var n = expression(0);
-                    advance(":");
-                    var v = expression(0);
-                    a.push([n, v]); // holds an array of name/value expression pairs
+                    if((node.id === ',' || node.id === '}') && n.id === '(name)') {
+                        const key = Object.create(symbol_table["(literal)"]);
+                        key.value = n.value;
+                        key.type = 'string';
+                        key.position = n.position;
+                        a.push([key, n]); // shorthand property syntax
+                    }
+                    else {
+                        advance(":");
+                        var v = expression(0);
+                        a.push([n, v]); // holds an array of name/value expression pairs
+                    }
                     if (node.id !== ",") {
                         break;
                     }

--- a/test/test-suite/groups/shorthand-property-notation/case000.json
+++ b/test/test-suite/groups/shorthand-property-notation/case000.json
@@ -1,0 +1,9 @@
+{
+    "expr": "{bar, \"foo\": foo.bar}",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {
+        "bar": 98,
+        "foo": 42
+    }
+}

--- a/test/test-suite/groups/shorthand-property-notation/case001.json
+++ b/test/test-suite/groups/shorthand-property-notation/case001.json
@@ -1,0 +1,9 @@
+{
+    "expr": "{\"foo\": foo.bar, bar}",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {
+        "bar": 98,
+        "foo": 42
+    }
+}

--- a/test/test-suite/groups/shorthand-property-notation/case002.json
+++ b/test/test-suite/groups/shorthand-property-notation/case002.json
@@ -1,0 +1,8 @@
+{
+    "expr": "($foobar:= 256; {$foobar})",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {
+        "foobar": 256
+    }
+}

--- a/test/test-suite/groups/shorthand-property-notation/case003.json
+++ b/test/test-suite/groups/shorthand-property-notation/case003.json
@@ -1,0 +1,9 @@
+{
+    "expr": "($bar:= 256; {\"foo\": foo.bar, $bar})",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {
+        "foo": 42,
+        "bar": 256
+    }
+}

--- a/test/test-suite/groups/shorthand-property-notation/case004.json
+++ b/test/test-suite/groups/shorthand-property-notation/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "($foo:= 256; {\"foo\": foo.bar, $foo})",
+    "dataset": "dataset0",
+    "bindings": {},
+    "code": "D1009"
+}

--- a/test/test-suite/groups/shorthand-property-notation/case005.json
+++ b/test/test-suite/groups/shorthand-property-notation/case005.json
@@ -1,0 +1,6 @@
+{
+    "expr": "{foo.bar}",
+    "dataset": "dataset0",
+    "bindings": {},
+    "code": "S0202"
+}


### PR DESCRIPTION
This Pull Request adds support for the shorthand property notation.

This allows to simplify an expression from:

```
{
  "a": a
}
```

to:

```
{
  a
}
```

This also works for variables:

```
(
  $foo:= 42;
  {$foo}
)
```

output:

```
{
  "foo": 42
}
```