### PR TITLE
feat: add default/elvis and coalescing operator

### DIFF
--- a/docs/other-operators.md
+++ b/docs/other-operators.md
@@ -27,7 +27,7 @@ __Example__
 
 ## `?:` (Default/Elvis)
 
-The default (or "elvis") operator returns the left-hand side if it is truthy, otherwise it returns the right-hand side. This is useful for providing fallback values when an expression may evaluate to a falsy value (such as `null`, `false`, `0`, `''`, or `undefined`).
+The default (or "elvis") operator returns the left-hand side if it has an effective Boolean value of `true`, otherwise it returns the right-hand side. This is useful for providing fallback values when an expression may evaluate to a value with an effective Boolean value of `false` (such as `null`, `false`, `0`, `''`, or `undefined`).
 
 __Syntax__
 
@@ -35,13 +35,11 @@ __Syntax__
 
 __Example__
 
-`foo.bar ?: 42` => `42` (if `foo.bar` is falsy)
-
-`foo.bar ?: 'default'` => `'default'` (if `foo.bar` is falsy)
+`foo.bar ?: 'default'` => `'default'` (if `foo.bar` is evaluates to Boolean `false`)
 
 ## `??` (Coalescing)
 
-The coalescing operator returns the left-hand side if it is defined (not `undefined`), otherwise it returns the right-hand side. This is useful for providing fallback values only when the left-hand side is missing or not present (empty sequence), but not for other falsy values like `0`, `false`, or `''`.
+The coalescing operator returns the left-hand side if it is defined (not `undefined`), otherwise it returns the right-hand side. This is useful for providing fallback values only when the left-hand side is missing or not present (empty sequence), but not for other values with an effective Boolean value of `false` like `0`, `false`, or `''`.
 
 __Syntax__
 

--- a/docs/other-operators.md
+++ b/docs/other-operators.md
@@ -25,6 +25,38 @@ __Example__
 
 `Price < 50 ? "Cheap" : "Expensive"`
 
+## `?:` (Default/Elvis)
+
+The default (or "elvis") operator returns the left-hand side if it is truthy, otherwise it returns the right-hand side. This is useful for providing fallback values when an expression may evaluate to a falsy value (such as `null`, `false`, `0`, `''`, or `undefined`).
+
+__Syntax__
+
+`<expr1> ?: <expr2>`
+
+__Example__
+
+`foo.bar ?: 42` => `42` (if `foo.bar` is falsy)
+
+`foo.bar ?: 'default'` => `'default'` (if `foo.bar` is falsy)
+
+## `??` (Coalescing)
+
+The coalescing operator returns the left-hand side if it is defined (not `undefined`), otherwise it returns the right-hand side. This is useful for providing fallback values only when the left-hand side is missing or not present (empty sequence), but not for other falsy values like `0`, `false`, or `''`.
+
+__Syntax__
+
+`<expr1> ?? <expr2>`
+
+__Example__
+
+`foo.bar ?? 42` => `42` (if `foo.bar` is undefined)
+
+`foo.bar ?? 'default'` => `'default'` (if `foo.bar` is undefined)
+
+`0 ?? 1` => `0`
+
+`'' ?? 'fallback'` => `''`
+
 ## `:=` (Variable binding)
 
 The variable binding operator is used to bind the value of the RHS to the variable name defined on the LHS.  The variable binding is scoped to the current block and any nested blocks.  It is an error if the LHS is not a `$` followed by a valid variable name.

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -40,6 +40,8 @@ Produces [this](http://try.jsonata.org/ryYn78Q0m), if you're interested!
 
 ## Conditional logic
 
+### Ternary operator (`? :`)
+
 If/then/else constructs can be written using the ternary operator "? :".
 
 `predicate ? expr1 : expr2`
@@ -64,6 +66,84 @@ __Examples__
   },
   {
     "Cloak": "Premium"
+  }
+]</div>
+</div>
+
+### Elvis/Default operator (`?:`)
+
+The default (or "elvis") operator is syntactic sugar for a common pattern using the ternary operator. It returns the left-hand side if it has an effective Boolean value of `true`, otherwise it returns the right-hand side.
+
+`expr1 ?: expr2`
+
+This is equivalent to:
+
+`expr1 ? expr1 : expr2`
+
+The elvis operator is useful for providing fallback values when an expression may evaluate to a value with an effective Boolean value of `false`, without having to repeat the expression twice as you would with the ternary operator.
+
+__Examples__
+
+<div class="jsonata-ex">
+  <div>Account.Order.Product.{
+    `Product Name`: $.'Product Name',
+    `Category`: $.Category ?: "Uncategorized"
+}</div>
+  <div>[
+  {
+    "Product Name": "Bowler Hat",
+    "Category": "Uncategorized"
+  },
+  {
+    "Product Name": "Trilby hat",
+    "Category": "Uncategorized"
+  },
+  {
+    "Product Name": "Bowler Hat",
+    "Category": "Uncategorized"
+  },
+  {
+    "Product Name": "Cloak",
+    "Category": "Uncategorized"
+  }
+]</div>
+</div>
+
+### Coalescing operator (`??`)
+
+The coalescing operator is syntactic sugar for a common pattern using the ternary operator with the `$exists` function. It returns the left-hand side if it is defined (not `undefined`), otherwise it returns the right-hand side.
+
+`expr1 ?? expr2`
+
+This is equivalent to:
+
+`$exists(expr1) ? expr1 : expr2`
+
+The coalescing operator is useful for providing fallback values only when the left-hand side is missing or not present (empty sequence), but not for other values with an effective Boolean value of `false` like `0`, `false`, or `''`. It avoids having to evaluate the expression twice and explicitly use the `$exists` function as you would with the ternary operator.
+
+__Examples__
+
+<div class="jsonata-ex">
+  <div>Account.Order.{
+    "OrderID": OrderID, 
+    Rating": ($sum(Product.Rating) / $count(Product.Rating)) ?? 0
+}</div>
+  <div>[
+  {
+    "OrderID": "order101",
+    "Rating": 5
+  },
+  {
+    "OrderID": "order102",
+    "Rating": 3
+  },
+  {
+    "OrderID": "order103",
+    "Rating": 4
+  },
+  {
+    "OrderID": "order104",
+    "Rating": 2
   }
 ]</div>
 </div>

--- a/src/functions.js
+++ b/src/functions.js
@@ -1420,7 +1420,7 @@ const functions = (() => {
             if (arg !== 0) {
                 result = true;
             }
-        } else if (arg !== null && typeof arg === 'object') {
+        } else if (arg !== null && typeof arg === 'object' && !isFunction(arg)) {
             if (Object.keys(arg).length > 0) {
                 result = true;
             }

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -482,6 +482,9 @@ var jsonata = (function() {
                 case '>=':
                     result = evaluateComparisonExpression(lhs, rhs, op);
                     break;
+                case '?:':
+                    result = evaluateDefault(lhs, rhs, op);
+                    break;                    
                 case '&':
                     result = evaluateStringConcat(lhs, rhs);
                     break;
@@ -808,6 +811,16 @@ var jsonata = (function() {
                 break;
         }
         return result;
+    }
+
+    /**
+     * Evaluate default-value expression
+     * @param {Object} lhs - LHS value
+     * @param {Object} rhs - RHS value
+     * @returns {*} Result
+     */
+    function evaluateDefault(lhs, rhs) {
+        return lhs ? lhs : rhs;
     }
 
     /**

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -482,12 +482,6 @@ var jsonata = (function() {
                 case '>=':
                     result = evaluateComparisonExpression(lhs, rhs, op);
                     break;
-                case '?:':
-                    result = evaluateDefaultExpression(lhs, rhs, op);
-                    break;
-                case '??':
-                    result = evaluateCoalescingExpression(lhs, rhs);
-                    break;
                 case '&':
                     result = evaluateStringConcat(lhs, rhs);
                     break;
@@ -814,29 +808,6 @@ var jsonata = (function() {
                 break;
         }
         return result;
-    }
-
-    /**
-     * Evaluate default-value expression
-     * @param {Object} lhs - LHS value
-     * @param {Object} rhs - RHS value
-     * @returns {*} Result
-     */
-    function evaluateDefaultExpression(lhs, rhs) {
-        return lhs ? lhs : rhs;
-    }
-
-    /**
-     * Evaluate coalescing expression
-     * @param {Object} lhs - LHS value
-     * @param {Object} rhs - RHS value
-     * @returns {*} Result
-     */
-    function evaluateCoalescingExpression(lhs, rhs) {
-        if (typeof lhs === 'undefined') {
-            return rhs;
-        }
-        return lhs;
     }
 
     /**

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -483,8 +483,11 @@ var jsonata = (function() {
                     result = evaluateComparisonExpression(lhs, rhs, op);
                     break;
                 case '?:':
-                    result = evaluateDefault(lhs, rhs, op);
-                    break;                    
+                    result = evaluateDefaultExpression(lhs, rhs, op);
+                    break;
+                case '??':
+                    result = evaluateCoalescingExpression(lhs, rhs);
+                    break;
                 case '&':
                     result = evaluateStringConcat(lhs, rhs);
                     break;
@@ -819,8 +822,21 @@ var jsonata = (function() {
      * @param {Object} rhs - RHS value
      * @returns {*} Result
      */
-    function evaluateDefault(lhs, rhs) {
+    function evaluateDefaultExpression(lhs, rhs) {
         return lhs ? lhs : rhs;
+    }
+
+    /**
+     * Evaluate coalescing expression
+     * @param {Object} lhs - LHS value
+     * @param {Object} rhs - RHS value
+     * @returns {*} Result
+     */
+    function evaluateCoalescingExpression(lhs, rhs) {
+        if (typeof lhs === 'undefined') {
+            return rhs;
+        }
+        return lhs;
     }
 
     /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -577,8 +577,20 @@ const parser = (() => {
         terminal("in"); //
         prefix("-"); // unary numeric negation
         infix("~>"); // function application
-        infix("?:"); // default value
-        infix("??"); // coalescing operator
+
+        // coalescing operator
+        infix("??", operators['??'], function (left) {
+            this.type = 'condition';
+            this.condition = {
+                type: 'function',
+                value: '(',
+                procedure: { type: 'variable', value: 'exists' },
+                arguments: [left]
+            };
+            this.then = left;
+            this.else = expression(0);
+            return this;
+        });
 
         infixr("(error)", 10, function (left) {
             this.lhs = left;
@@ -860,6 +872,15 @@ const parser = (() => {
                 advance(":");
                 this.else = expression(0);
             }
+            return this;
+        });
+
+        // elvis/default operator
+        infix("?:", operators['?:'], function (left) {
+            this.type = 'condition';
+            this.condition = left;
+            this.then = left;
+            this.else = expression(0);
             return this;
         });
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -40,6 +40,7 @@ const parser = (() => {
         '<=': 40,
         '>=': 40,
         '~>': 40,
+        '?:': 40,
         'and': 30,
         'or': 25,
         'in': 40,
@@ -197,6 +198,11 @@ const parser = (() => {
                 // ~>  chain function
                 position += 2;
                 return create('operator', '~>');
+            }
+            if (currentChar === '?' && path.charAt(position + 1) === ':') {
+                // ?: default / elvis operator
+                position += 2;
+                return create('operator', '?:');
             }
             // test for single char operators
             if (Object.prototype.hasOwnProperty.call(operators, currentChar)) {
@@ -565,6 +571,7 @@ const parser = (() => {
         terminal("in"); //
         prefix("-"); // unary numeric negation
         infix("~>"); // function application
+        infix("?:"); // default value
 
         infixr("(error)", 10, function (left) {
             this.lhs = left;

--- a/src/parser.js
+++ b/src/parser.js
@@ -41,6 +41,7 @@ const parser = (() => {
         '>=': 40,
         '~>': 40,
         '?:': 40,
+        '??': 40,
         'and': 30,
         'or': 25,
         'in': 40,
@@ -203,6 +204,11 @@ const parser = (() => {
                 // ?: default / elvis operator
                 position += 2;
                 return create('operator', '?:');
+            }
+            if (currentChar === '?' && path.charAt(position + 1) === '?') {
+                // ?? coalescing operator
+                position += 2;
+                return create('operator', '??');
             }
             // test for single char operators
             if (Object.prototype.hasOwnProperty.call(operators, currentChar)) {
@@ -572,6 +578,7 @@ const parser = (() => {
         prefix("-"); // unary numeric negation
         infix("~>"); // function application
         infix("?:"); // default value
+        infix("??"); // coalescing operator
 
         infixr("(error)", 10, function (left) {
             this.lhs = left;

--- a/test/test-suite/groups/coalescing-operator/case000.json
+++ b/test/test-suite/groups/coalescing-operator/case000.json
@@ -1,0 +1,6 @@
+{
+    "expr": "bar ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 98
+}

--- a/test/test-suite/groups/coalescing-operator/case001.json
+++ b/test/test-suite/groups/coalescing-operator/case001.json
@@ -1,0 +1,6 @@
+{
+    "expr": "foo.bar ?? 98",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/coalescing-operator/case002.json
+++ b/test/test-suite/groups/coalescing-operator/case002.json
@@ -1,0 +1,6 @@
+{
+    "expr": "foo.blah[0].baz.fud ?? 98",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": "hello"
+}

--- a/test/test-suite/groups/coalescing-operator/case003.json
+++ b/test/test-suite/groups/coalescing-operator/case003.json
@@ -1,4 +1,5 @@
 {
+    "description": "undefined property uses default number on rhs",
     "expr": "baz ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case003.json
+++ b/test/test-suite/groups/coalescing-operator/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "baz ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/coalescing-operator/case004.json
+++ b/test/test-suite/groups/coalescing-operator/case004.json
@@ -1,4 +1,5 @@
 {
+    "description": "property missing on object uses default number on rhs",
     "expr": "foo.baz ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case004.json
+++ b/test/test-suite/groups/coalescing-operator/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "foo.baz ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/coalescing-operator/case005.json
+++ b/test/test-suite/groups/coalescing-operator/case005.json
@@ -1,4 +1,5 @@
 {
+    "description": "out of bounds index uses default number on rhs",
     "expr": "foo.blah[9].baz.fud ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case005.json
+++ b/test/test-suite/groups/coalescing-operator/case005.json
@@ -1,0 +1,6 @@
+{
+    "expr": "foo.blah[9].baz.fud ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/coalescing-operator/case006.json
+++ b/test/test-suite/groups/coalescing-operator/case006.json
@@ -1,0 +1,6 @@
+{
+    "expr": "null ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": null
+}

--- a/test/test-suite/groups/coalescing-operator/case006.json
+++ b/test/test-suite/groups/coalescing-operator/case006.json
@@ -1,4 +1,5 @@
 {
+    "description": "null is used",
     "expr": "null ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case007.json
+++ b/test/test-suite/groups/coalescing-operator/case007.json
@@ -1,4 +1,5 @@
 {
+    "description": "false is used",
     "expr": "false ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case007.json
+++ b/test/test-suite/groups/coalescing-operator/case007.json
@@ -1,0 +1,6 @@
+{
+    "expr": "false ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": false
+}

--- a/test/test-suite/groups/coalescing-operator/case008.json
+++ b/test/test-suite/groups/coalescing-operator/case008.json
@@ -1,4 +1,5 @@
 {
+    "description": "true is used",
     "expr": "true ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case008.json
+++ b/test/test-suite/groups/coalescing-operator/case008.json
@@ -1,0 +1,6 @@
+{
+    "expr": "true ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": true
+}

--- a/test/test-suite/groups/coalescing-operator/case009.json
+++ b/test/test-suite/groups/coalescing-operator/case009.json
@@ -1,0 +1,6 @@
+{
+    "expr": "0 ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 0
+}

--- a/test/test-suite/groups/coalescing-operator/case009.json
+++ b/test/test-suite/groups/coalescing-operator/case009.json
@@ -1,4 +1,5 @@
 {
+    "description": "0 is used",
     "expr": "0 ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/coalescing-operator/case010.json
+++ b/test/test-suite/groups/coalescing-operator/case010.json
@@ -1,0 +1,6 @@
+{
+    "expr": "[] ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": []
+}

--- a/test/test-suite/groups/coalescing-operator/case011.json
+++ b/test/test-suite/groups/coalescing-operator/case011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "{} ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {}
+}

--- a/test/test-suite/groups/coalescing-operator/case012.json
+++ b/test/test-suite/groups/coalescing-operator/case012.json
@@ -1,0 +1,6 @@
+{
+    "expr": "\"\" ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": ""
+}

--- a/test/test-suite/groups/coalescing-operator/case012.json
+++ b/test/test-suite/groups/coalescing-operator/case012.json
@@ -1,4 +1,5 @@
 {
+    "description": "empty string is used",
     "expr": "\"\" ?? 42",
     "dataset": "dataset0",
     "bindings": {},

--- a/test/test-suite/groups/default-operator/case000.json
+++ b/test/test-suite/groups/default-operator/case000.json
@@ -1,7 +1,7 @@
 {
-    "description": "property missing on object uses default string on lhs",
-    "expr": "order?:'the usual'",
+    "description": "true is used",
+    "expr": "true ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": "the usual"
+    "result": true
 }

--- a/test/test-suite/groups/default-operator/case000.json
+++ b/test/test-suite/groups/default-operator/case000.json
@@ -1,0 +1,7 @@
+{
+    "description": "property missing on object uses default string on lhs",
+    "expr": "order?:'the usual'",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": "the usual"
+}

--- a/test/test-suite/groups/default-operator/case001.json
+++ b/test/test-suite/groups/default-operator/case001.json
@@ -1,6 +1,6 @@
 {
-    "description": "property missing on object uses default number on lhs",
-    "expr": "age?:42",
+    "description": "false is not used",
+    "expr": "false ?: 42",
     "dataset": "dataset0",
     "bindings": {},
     "result": 42

--- a/test/test-suite/groups/default-operator/case001.json
+++ b/test/test-suite/groups/default-operator/case001.json
@@ -1,0 +1,7 @@
+{
+    "description": "property missing on object uses default number on lhs",
+    "expr": "age?:42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case002.json
+++ b/test/test-suite/groups/default-operator/case002.json
@@ -1,0 +1,7 @@
+{
+    "description": "1 is used",
+    "expr": "1 ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 1
+}

--- a/test/test-suite/groups/default-operator/case003.json
+++ b/test/test-suite/groups/default-operator/case003.json
@@ -1,0 +1,7 @@
+{
+    "description": "property present on object is used",
+    "expr": "bar ?: 0",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 98
+}

--- a/test/test-suite/groups/default-operator/case003.json
+++ b/test/test-suite/groups/default-operator/case003.json
@@ -1,7 +1,7 @@
 {
-    "description": "property present on object is used",
-    "expr": "bar ?: 0",
+    "description": "0 is not used",
+    "expr": "0 ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": 98
+    "result": 42
 }

--- a/test/test-suite/groups/default-operator/case004.json
+++ b/test/test-suite/groups/default-operator/case004.json
@@ -1,7 +1,7 @@
 {
-    "description": "operator can be chained",
-    "expr": "nope ?: foo.bar ?: 0",
+    "description": "hello is used",
+    "expr": "\"hello\" ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": 42
+    "result": "hello"
 }

--- a/test/test-suite/groups/default-operator/case004.json
+++ b/test/test-suite/groups/default-operator/case004.json
@@ -1,0 +1,7 @@
+{
+    "description": "operator can be chained",
+    "expr": "nope ?: foo.bar ?: 0",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case005.json
+++ b/test/test-suite/groups/default-operator/case005.json
@@ -1,0 +1,7 @@
+{
+    "description": "empty string is not used",
+    "expr": "\"\" ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case006.json
+++ b/test/test-suite/groups/default-operator/case006.json
@@ -1,0 +1,7 @@
+{
+    "description": "0 is not used",
+    "expr": "0 ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case006.json
+++ b/test/test-suite/groups/default-operator/case006.json
@@ -1,7 +1,9 @@
 {
-    "description": "0 is not used",
-    "expr": "0 ?: 42",
+    "description": "[1] is used",
+    "expr": "[1] ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": 42
+    "result": [
+        1
+    ]
 }

--- a/test/test-suite/groups/default-operator/case007.json
+++ b/test/test-suite/groups/default-operator/case007.json
@@ -1,0 +1,7 @@
+{
+    "description": "false is not used",
+    "expr": "false ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case008.json
+++ b/test/test-suite/groups/default-operator/case008.json
@@ -1,6 +1,6 @@
 {
     "description": "empty array is used",
-    "expr": "[] ?? 42",
+    "expr": "[] ?: 42",
     "dataset": "dataset0",
     "bindings": {},
     "result": []

--- a/test/test-suite/groups/default-operator/case008.json
+++ b/test/test-suite/groups/default-operator/case008.json
@@ -1,7 +1,7 @@
 {
-    "description": "empty array is used",
+    "description": "empty array is not used",
     "expr": "[] ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": []
+    "result": 42
 }

--- a/test/test-suite/groups/default-operator/case009.json
+++ b/test/test-suite/groups/default-operator/case009.json
@@ -1,7 +1,9 @@
 {
-    "description": "empty object is used",
-    "expr": "{} ?: 42",
+    "description": "object with property is used",
+    "expr": "{ \"a\": 1 } ?: 42",
     "dataset": "dataset0",
     "bindings": {},
-    "result": {}
+    "result": {
+        "a": 1
+    }
 }

--- a/test/test-suite/groups/default-operator/case009.json
+++ b/test/test-suite/groups/default-operator/case009.json
@@ -1,6 +1,6 @@
 {
     "description": "empty object is used",
-    "expr": "{} ?? 42",
+    "expr": "{} ?: 42",
     "dataset": "dataset0",
     "bindings": {},
     "result": {}

--- a/test/test-suite/groups/default-operator/case010.json
+++ b/test/test-suite/groups/default-operator/case010.json
@@ -1,0 +1,7 @@
+{
+    "description": "empty object is not used",
+    "expr": "{} ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case011.json
+++ b/test/test-suite/groups/default-operator/case011.json
@@ -1,0 +1,7 @@
+{
+    "description": "function is not used",
+    "expr": "function(){true} ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case012.json
+++ b/test/test-suite/groups/default-operator/case012.json
@@ -1,6 +1,6 @@
 {
-    "description": "[0] is not used",
-    "expr": "[0] ?: 42",
+    "description": "42 is used",
+    "expr": "Account.blah ?: 42",
     "dataset": "dataset0",
     "bindings": {},
     "result": 42

--- a/test/test-suite/groups/default-operator/case013.json
+++ b/test/test-suite/groups/default-operator/case013.json
@@ -1,6 +1,6 @@
 {
-    "description": "[0] is not used",
-    "expr": "[0] ?: 42",
+    "description": "42 is used",
+    "expr": "Account.blah ?: 42",
     "dataset": "dataset0",
     "bindings": {},
     "result": 42


### PR DESCRIPTION
This PR continues the work of @markmelville in PR https://github.com/jsonata-js/jsonata/pull/638 for the elvis/default operator `A ?: B` and adds the coalescing operator `A ?? B` as described by @andrew-coleman 
> Coalescing operator `A ?? B` which will evaluate to B iff A does not exist (empty sequence). Equivalent to `[A, B](0)` (from XPath).
> https://github.com/jsonata-js/jsonata/pull/638#issuecomment-1584301119

I followed the logic of `$exists()` when evaluating the LHS which only checks for `undefined`, that means other falsy values like `null` are evaluated as true. This could be changed to also include `null` to match the behavior of JavaScript's `??` operator.