### PR TITLE
Reflect missing behaviours on map in docs

### DIFF
--- a/docs/higher-order-functions.md
+++ b/docs/higher-order-functions.md
@@ -7,7 +7,31 @@ sidebar_label: Higher Order Functions
 ## `$map()`
 __Signature:__ `$map(array, function)`
 
-Returns an array containing the results of applying the `function` parameter to each value in the `array` parameter.
+If the input argument is an array of 2 or more elements, returns an array containing the results of applying the `function` parameter to each value in the `array` parameter.
+
+```
+$map([1,2,3], function($v) { $v * 2 })
+```
+
+evaluates to
+
+```
+[ 2, 4, 6 ]
+```
+
+If the input argument is an array with 1 element, returns the single result of applying the `function` parameter to each value in the `array` parameter.
+
+```
+$map([2], function($v) { $v * 2 })
+```
+
+evaluates to
+
+```
+4
+```
+
+If the input argument is an empty array, returns `undefined`
 
 The function that is supplied as the second parameter must have the following signature:
 

--- a/docs/higher-order-functions.md
+++ b/docs/higher-order-functions.md
@@ -31,7 +31,7 @@ evaluates to
 4
 ```
 
-If the input argument is an empty array, returns `undefined`
+If the input argument is an empty array, returns nothing (represented in Javascript as `undefined`)
 
 The function that is supplied as the second parameter must have the following signature:
 


### PR DESCRIPTION
https://github.com/jsonata-js/jsonata/issues/462 and https://github.com/jsonata-js/jsonata/issues/708 both reflect seemingly unexpected behaviour in how map works. 

At the very least - the current behaviour has been in there for several versions now and is completely undocumented. This heavily throws new-time readers and AI tools parsing the docs. 

This is my 5 min attempt to alleviate that issue. 

I am unsure on whether `undefined` is the right term for the empty array case - potentially that needs correcting. But regardless - something is better than nothing! 