### PR TITLE
Add removeEmpty function to allow easy removal of NULL values, empty strings, empty objects and empty arrays

### DIFF
--- a/docs/object-functions.md
+++ b/docs/object-functions.md
@@ -76,4 +76,119 @@ Evaluates the type of `value` and returns one of the following strings:
 * `"function"`
 Returns (non-string) `undefined` when `value` is `undefined`.
 
+## `$removeEmpty()`
+__Signature:__ `$removeEmpty(input, exclusionList?, removeEmptyStrings?)`
+
+Recursively removes empty values from objects and arrays, creating a cleaned version of the input data structure. Empty objects `{}`, empty arrays `[]`, `null` values, and optionally empty strings `""` are removed. The function preserves the original structure while eliminating empty elements.
+
+**Parameters:**
+- `input` - The data structure to clean up (object, array, or primitive value)
+- `exclusionList` (optional) - Array of dot-notation paths to exclude from cleaning. Paths can optionally start with `$.`
+- `removeEmptyStrings` (optional) - Boolean flag to control removal of empty strings (default: `true`)
+
+**Examples**
+
+Basic cleanup of an object:
+```
+$removeEmpty({
+  "name": "John",
+  "email": "",
+  "profile": {
+    "bio": null,
+    "settings": {},
+    "preferences": []
+  },
+  "active": true
+})
+```
+=>
+```
+{
+  "name": "John",
+  "active": true
+}
+```
+
+Cleanup with exclusions to preserve specific empty values:
+```
+$removeEmpty({
+  "required": "",
+  "optional": "",
+  "config": {}
+}, ["required", "config"])
+```
+=>
+```
+{
+  "required": "",
+  "config": {}
+}
+```
+
+Preserving empty strings by setting `removeEmptyStrings` to `false`:
+```
+$removeEmpty({
+  "name": "Jane",
+  "middle": "",
+  "last": "Doe",
+  "metadata": null
+}, [], false)
+```
+=>
+```
+{
+  "name": "Jane",
+  "middle": "",
+  "last": "Doe"
+}
+```
+
+Cleaning arrays with mixed content:
+```
+$removeEmpty([
+  "valid",
+  "",
+  null,
+  {"key": "value"},
+  {},
+  [],
+  42
+])
+```
+=>
+```
+[
+  "valid",
+  {"key": "value"},
+  42
+]
+```
+
+Using path exclusions with nested objects:
+```
+$removeEmpty({
+  "user": {
+    "name": "Alice",
+    "bio": "",
+    "social": {
+      "twitter": "",
+      "github": "alice123"
+    }
+  }
+}, ["user.bio", "user.social.twitter"])
+```
+=>
+```
+{
+  "user": {
+    "name": "Alice",
+    "bio": "",
+    "social": {
+      "twitter": "",
+      "github": "alice123"
+    }
+  }
+}
+```
+
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -2056,6 +2056,92 @@ const functions = (() => {
         return result;
     }
 
+    /**
+     * Clean up empty values from an object or array
+     * @param {*} input - The input value to clean
+     * @param {Array} exclusionList - Array of paths to exclude from cleaning (optional)
+     * @param {boolean} removeEmptyStrings - Whether to remove empty strings (optional, default true)
+     * @param {string} currentPath - Current path for internal recursion (optional)
+     * @returns {*} Cleaned input with empty objects, arrays, and optionally strings removed
+     */
+    function removeEmpty(input, exclusionList, removeEmptyStrings, currentPath) {
+        // Handle undefined input
+        if (typeof input === 'undefined') {
+            return undefined;
+        }
+
+        // Set default values
+        exclusionList = exclusionList || [];
+        removeEmptyStrings = (removeEmptyStrings !== false); // default to true
+        currentPath = currentPath || '';
+
+        // Helper to check if currentPath matches any exclusion path
+        var isExcluded = exclusionList.some(function(exclusionPath) {
+            var normalizedExclusionPath = exclusionPath.indexOf('$.') === 0 ? exclusionPath.slice(2) : exclusionPath;
+            return normalizedExclusionPath === currentPath;
+        });
+
+        if (isExcluded) {
+            // If the current path is excluded, return the object/array/value as is, without cleaning children
+            return input;
+        }
+
+        if (Array.isArray(input)) {
+            var cleanedArray = input
+                .map(function(item, idx) {
+                    return removeEmpty(item, exclusionList, removeEmptyStrings, currentPath + '[' + idx + ']');
+                })
+                .filter(function(item) {
+                    // Filter out undefined values
+                    if (typeof item === 'undefined') {
+                        return false;
+                    }
+                    // Filter out empty objects and arrays
+                    if (typeof item === 'object' && item !== null) {
+                        return Object.keys(item).length > 0 || (Array.isArray(item) && item.length > 0);
+                    }
+                    // Keep everything else (including null, strings, numbers, booleans)
+                    return true;
+                });
+            return cleanedArray;
+        } else if (typeof input === 'object' && input !== null) {
+            var cleanedObject = {};
+            var keys = Object.keys(input);
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                var nextPath = currentPath ? currentPath + '.' + key : key;
+                // Check if the nextPath is excluded before recursing
+                var isChildExcluded = exclusionList.some(function(exclusionPath) {
+                    var normalizedExclusionPath = exclusionPath.indexOf('$.') === 0 ? exclusionPath.slice(2) : exclusionPath;
+                    return normalizedExclusionPath === nextPath;
+                });
+                if (isChildExcluded) {
+                    cleanedObject[key] = input[key];
+                } else {
+                    var value = removeEmpty(input[key], exclusionList, removeEmptyStrings, nextPath);
+                    if (
+                        typeof value !== 'undefined' &&
+                        value !== null &&
+                        !(typeof value === 'object' && value !== null && Object.keys(value).length === 0) &&
+                        !(Array.isArray(value) && value.length === 0) &&
+                        !(removeEmptyStrings && value === '')
+                    ) {
+                        cleanedObject[key] = value;
+                    }
+                }
+            }
+            // Return undefined if the cleaned object is empty
+            return Object.keys(cleanedObject).length === 0 ? undefined : cleanedObject;
+        }
+
+        // Handle empty strings
+        if (removeEmptyStrings && input === '') {
+            return undefined;
+        }
+
+        return input;
+    }
+
     return {
         sum, count, max, min, average,
         string, substring, substringBefore, substringAfter, lowercase, uppercase, length, trim, pad,
@@ -2064,7 +2150,8 @@ const functions = (() => {
         boolean, not,
         map, zip, filter, single, foldLeft, sift,
         keys, lookup, append, exists, spread, merge, reverse, each, error, assert, type, sort, shuffle, distinct,
-        base64encode, base64decode,  encodeUrlComponent, encodeUrl, decodeUrlComponent, decodeUrl
+        base64encode, base64decode,  encodeUrlComponent, encodeUrl, decodeUrlComponent, decodeUrl,
+        removeEmpty
     };
 })();
 

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1929,6 +1929,7 @@ var jsonata = (function() {
     staticFrame.bind('encodeUrl', defineFunction(fn.encodeUrl, '<s-:s>'));
     staticFrame.bind('decodeUrlComponent', defineFunction(fn.decodeUrlComponent, '<s-:s>'));
     staticFrame.bind('decodeUrl', defineFunction(fn.decodeUrl, '<s-:s>'));
+    staticFrame.bind('removeEmpty', defineFunction(fn.removeEmpty, '<j-a<s>?b?:j>'));
     staticFrame.bind('eval', defineFunction(functionEval, '<sx?:x>'));
     staticFrame.bind('toMillis', defineFunction(datetime.toMillis, '<s-s?:n>'));
     staticFrame.bind('fromMillis', defineFunction(datetime.fromMillis, '<n-s?s?:s>'));

--- a/test/test-suite/datasets/dataset25.json
+++ b/test/test-suite/datasets/dataset25.json
@@ -1,0 +1,87 @@
+{
+    "user": {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "profile": {
+            "bio": "",
+            "website": null,
+            "social": {
+                "twitter": "",
+                "linkedin": "https://linkedin.com/in/johndoe",
+                "facebook": null
+            },
+            "preferences": {
+                "notifications": {},
+                "privacy": {
+                    "public": true,
+                    "settings": []
+                }
+            }
+        },
+        "contacts": [],
+        "projects": [
+            {
+                "name": "Project Alpha",
+                "description": "A sample project",
+                "tags": ["work", "important"],
+                "metadata": {
+                    "created": "2023-01-15",
+                    "updated": null,
+                    "notes": ""
+                }
+            },
+            {
+                "name": "",
+                "description": null,
+                "tags": [],
+                "metadata": {}
+            }
+        ],
+        "settings": {
+            "theme": "dark",
+            "language": "en",
+            "features": {
+                "beta": false,
+                "experimental": {}
+            }
+        }
+    },
+    "organization": {
+        "name": "ACME Corp",
+        "departments": [
+            {
+                "name": "Engineering",
+                "employees": [
+                    {
+                        "name": "Alice Smith",
+                        "role": "Developer",
+                        "skills": ["JavaScript", "Python"],
+                        "certifications": []
+                    },
+                    {
+                        "name": "",
+                        "role": null,
+                        "skills": [],
+                        "certifications": null
+                    }
+                ],
+                "budget": {
+                    "allocated": 100000,
+                    "spent": 0,
+                    "remaining": null
+                }
+            },
+            {
+                "name": "",
+                "employees": [],
+                "budget": {}
+            }
+        ],
+        "locations": [],
+        "policies": {
+            "remote": true,
+            "benefits": {},
+            "training": []
+        }
+    }
+}

--- a/test/test-suite/datasets/dataset26.json
+++ b/test/test-suite/datasets/dataset26.json
@@ -1,0 +1,65 @@
+{
+    "data": {
+        "arrays": {
+            "empty": [],
+            "mixed": [1, "", null, {}, [], "valid"],
+            "nested": [
+                {
+                    "id": 1,
+                    "value": "test",
+                    "meta": {}
+                },
+                {
+                    "id": null,
+                    "value": "",
+                    "meta": {
+                        "tags": [],
+                        "flags": {}
+                    }
+                },
+                []
+            ]
+        },
+        "objects": {
+            "empty": {},
+            "partial": {
+                "valid": "data",
+                "empty_string": "",
+                "null_value": null,
+                "empty_object": {},
+                "empty_array": []
+            },
+            "nested": {
+                "level1": {
+                    "level2": {
+                        "level3": {
+                            "data": "",
+                            "more": {}
+                        }
+                    },
+                    "other": null
+                }
+            }
+        },
+        "primitives": {
+            "string": "valid",
+            "empty_string": "",
+            "null": null,
+            "number": 42,
+            "zero": 0,
+            "boolean": true,
+            "false": false
+        },
+        "exclusion_test": {
+            "keep_empty_string": "",
+            "keep_empty_object": {},
+            "keep_empty_array": [],
+            "nested_exclusion": {
+                "deep": {
+                    "empty_to_keep": "",
+                    "empty_to_remove": {}
+                }
+            }
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case000.json
+++ b/test/test-suite/groups/function-removeEmpty/case000.json
@@ -1,0 +1,6 @@
+{
+    "expr": "[$removeEmpty(undefined), $removeEmpty(null), $removeEmpty(\"test string\"), $removeEmpty(\"\"), $removeEmpty(42), $removeEmpty({}), $removeEmpty([])]",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [null, "test string", 42]
+}

--- a/test/test-suite/groups/function-removeEmpty/case001.json
+++ b/test/test-suite/groups/function-removeEmpty/case001.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$removeEmpty(\"\", [], false)",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": ""
+}

--- a/test/test-suite/groups/function-removeEmpty/case002.json
+++ b/test/test-suite/groups/function-removeEmpty/case002.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty({\"valid\": \"data\", \"empty\": \"\", \"null\": null, \"emptyObj\": {}, \"emptyArr\": []})",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "valid": "data"
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case003.json
+++ b/test/test-suite/groups/function-removeEmpty/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$removeEmpty([1, \"\", null, {}, [], \"valid\"])",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [1, null, "valid"]
+}

--- a/test/test-suite/groups/function-removeEmpty/case004.json
+++ b/test/test-suite/groups/function-removeEmpty/case004.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty(data.objects.partial)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "valid": "data"
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case005.json
+++ b/test/test-suite/groups/function-removeEmpty/case005.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty({\"keep\": \"\", \"remove\": \"\"}, [\"keep\"])",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "keep": ""
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case006.json
+++ b/test/test-suite/groups/function-removeEmpty/case006.json
@@ -1,0 +1,9 @@
+{
+    "expr": "$removeEmpty(data.exclusion_test, [\"keep_empty_string\", \"keep_empty_object\"])",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "keep_empty_string": "",
+        "keep_empty_object": {}
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case007.json
+++ b/test/test-suite/groups/function-removeEmpty/case007.json
@@ -1,0 +1,12 @@
+{
+    "expr": "$removeEmpty(data.exclusion_test, [\"nested_exclusion.deep.empty_to_keep\"])",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "nested_exclusion": {
+            "deep": {
+                "empty_to_keep": ""
+            }
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case008.json
+++ b/test/test-suite/groups/function-removeEmpty/case008.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty(data.exclusion_test, [\"$.keep_empty_array\"])",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "keep_empty_array": []
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case009.json
+++ b/test/test-suite/groups/function-removeEmpty/case009.json
@@ -1,0 +1,38 @@
+{
+    "expr": "$removeEmpty(user, [\"profile.social.twitter\", \"contacts\"])",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "profile": {
+            "social": {
+                "linkedin": "https://linkedin.com/in/johndoe",
+                "twitter": ""
+            },
+            "preferences": {
+                "privacy": {
+                    "public": true
+                }
+            }
+        },
+        "contacts": [],
+        "projects": [
+            {
+                "name": "Project Alpha",
+                "description": "A sample project",
+                "tags": ["work", "important"],
+                "metadata": {
+                    "created": "2023-01-15"
+                }
+            }
+        ],
+        "settings": {
+            "theme": "dark",
+            "language": "en",
+            "features": {
+                "beta": false
+            }
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case010.json
+++ b/test/test-suite/groups/function-removeEmpty/case010.json
@@ -1,0 +1,11 @@
+{
+    "expr": "$removeEmpty(data.arrays.nested)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": [
+        {
+            "id": 1,
+            "value": "test"
+        }
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case011.json
+++ b/test/test-suite/groups/function-removeEmpty/case011.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$removeEmpty(data.objects.nested)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "undefinedResult": true
+}

--- a/test/test-suite/groups/function-removeEmpty/case012.json
+++ b/test/test-suite/groups/function-removeEmpty/case012.json
@@ -1,0 +1,21 @@
+{
+    "expr": "$removeEmpty(organization.departments)",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [
+        {
+            "name": "Engineering",
+            "employees": [
+                {
+                    "name": "Alice Smith",
+                    "role": "Developer",
+                    "skills": ["JavaScript", "Python"]
+                }
+            ],
+            "budget": {
+                "allocated": 100000,
+                "spent": 0
+            }
+        }
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case013.json
+++ b/test/test-suite/groups/function-removeEmpty/case013.json
@@ -1,0 +1,12 @@
+{
+    "expr": "$removeEmpty(data.primitives)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "string": "valid",
+        "number": 42,
+        "zero": 0,
+        "boolean": true,
+        "false": false
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case014.json
+++ b/test/test-suite/groups/function-removeEmpty/case014.json
@@ -1,0 +1,13 @@
+{
+    "expr": "$removeEmpty(data.primitives, [], false)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "string": "valid",
+        "empty_string": "",
+        "number": 42,
+        "zero": 0,
+        "boolean": true,
+        "false": false
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case015.json
+++ b/test/test-suite/groups/function-removeEmpty/case015.json
@@ -1,0 +1,13 @@
+{
+    "expr": "[$removeEmpty({\"empty\": \"\", \"null\": null, \"emptyObj\": {}}, [\"\"]), $removeEmpty([[1, \"\", null, {}, []]], [\"$.\"])]",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [
+        {
+            "empty": "",
+            "null": null,
+            "emptyObj": {}
+        },
+        [1, "", null, {}, []]
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case016.json
+++ b/test/test-suite/groups/function-removeEmpty/case016.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty({\"empty\": \"\", \"valid\": \"data\", \"null\": null})",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "valid": "data"
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case017.json
+++ b/test/test-suite/groups/function-removeEmpty/case017.json
@@ -1,0 +1,6 @@
+{
+    "expr": "[$removeEmpty({\"test\": \"value\"}, {\"invalid\": \"object\"}), $removeEmpty({\"test\": \"value\"}, [\"valid\", 123, \"another\"]), $removeEmpty({\"test\": \"value\"}, [], \"not_a_boolean\"), $removeEmpty({\"test\": \"value\"}, [], 123), $removeEmpty({\"test\": \"value\"}, [], {\"invalid\": \"object\"})]",
+    "dataset": "dataset25",
+    "bindings": {},
+    "code": "T0410"
+}

--- a/test/test-suite/groups/function-removeEmpty/case018.json
+++ b/test/test-suite/groups/function-removeEmpty/case018.json
@@ -1,0 +1,18 @@
+{
+    "expr": "[$removeEmpty({\"test\": \"value\", \"empty\": \"\"}, [\"empty\"]), $removeEmpty({\"test\": \"value\", \"empty\": \"\"}, [], true), $removeEmpty({\"test\": \"value\", \"empty\": \"\"}, [], false)]",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [
+        {
+            "test": "value",
+            "empty": ""
+        },
+        {
+            "test": "value"
+        },
+        {
+            "test": "value",
+            "empty": ""
+        }
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case019.json
+++ b/test/test-suite/groups/function-removeEmpty/case019.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty({\"test\": \"value\", \"empty\": \"\"}, [], true)",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "test": "value"
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case020.json
+++ b/test/test-suite/groups/function-removeEmpty/case020.json
@@ -1,0 +1,76 @@
+{
+    "expr": "{\"cleaned_user\": $removeEmpty(user), \"original_org\": organization}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "cleaned_user": {
+            "name": "John Doe",
+            "email": "john@example.com",
+            "profile": {
+                "social": {
+                    "linkedin": "https://linkedin.com/in/johndoe"
+                },
+                "preferences": {
+                    "privacy": {
+                        "public": true
+                    }
+                }
+            },
+            "projects": [
+                {
+                    "name": "Project Alpha",
+                    "description": "A sample project",
+                    "tags": ["work", "important"],
+                    "metadata": {
+                        "created": "2023-01-15"
+                    }
+                }
+            ],
+            "settings": {
+                "theme": "dark",
+                "language": "en",
+                "features": {
+                    "beta": false
+                }
+            }
+        },
+        "original_org": {
+            "name": "ACME Corp",
+            "departments": [
+                {
+                    "name": "Engineering",
+                    "employees": [
+                        {
+                            "name": "Alice Smith",
+                            "role": "Developer",
+                            "skills": ["JavaScript", "Python"],
+                            "certifications": []
+                        },
+                        {
+                            "name": "",
+                            "role": null,
+                            "skills": [],
+                            "certifications": null
+                        }
+                    ],
+                    "budget": {
+                        "allocated": 100000,
+                        "spent": 0,
+                        "remaining": null
+                    }
+                },
+                {
+                    "name": "",
+                    "employees": [],
+                    "budget": {}
+                }
+            ],
+            "locations": [],
+            "policies": {
+                "remote": true,
+                "benefits": {},
+                "training": []
+            }
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case021.json
+++ b/test/test-suite/groups/function-removeEmpty/case021.json
@@ -1,0 +1,19 @@
+{
+    "expr": "$map(organization.departments, function($dept) { $removeEmpty($dept) })",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "name": "Engineering",
+        "employees": [
+            {
+                "name": "Alice Smith",
+                "role": "Developer",
+                "skills": ["JavaScript", "Python"]
+            }
+        ],
+        "budget": {
+            "allocated": 100000,
+            "spent": 0
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case022.json
+++ b/test/test-suite/groups/function-removeEmpty/case022.json
@@ -1,0 +1,11 @@
+{
+    "expr": "user.projects[name != \"\"].{\"project\": name, \"clean_metadata\": $removeEmpty(metadata)}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "project": "Project Alpha",
+        "clean_metadata": {
+            "created": "2023-01-15"
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case023.json
+++ b/test/test-suite/groups/function-removeEmpty/case023.json
@@ -1,0 +1,18 @@
+{
+    "expr": "data.arrays.nested.{\"id\": id, \"cleaned\": $removeEmpty($)}",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": [
+        {
+            "id": 1,
+            "cleaned": {
+                "id": 1,
+                "value": "test"
+            }
+        },
+        {
+            "id": null
+        },
+        {}
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case024.json
+++ b/test/test-suite/groups/function-removeEmpty/case024.json
@@ -1,0 +1,27 @@
+{
+    "expr": "[$removeEmpty(user.profile), $removeEmpty(user.profile, [], true)]",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [
+        {
+            "social": {
+                "linkedin": "https://linkedin.com/in/johndoe"
+            },
+            "preferences": {
+                "privacy": {
+                    "public": true
+                }
+            }
+        },
+        {
+            "social": {
+                "linkedin": "https://linkedin.com/in/johndoe"
+            },
+            "preferences": {
+                "privacy": {
+                    "public": true
+                }
+            }
+        }
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case025.json
+++ b/test/test-suite/groups/function-removeEmpty/case025.json
@@ -1,0 +1,8 @@
+{
+    "expr": "$removeEmpty(data.objects.partial)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "valid": "data"
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case026.json
+++ b/test/test-suite/groups/function-removeEmpty/case026.json
@@ -1,0 +1,10 @@
+{
+    "expr": "$removeEmpty(organization.departments[0].employees[0])",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "name": "Alice Smith",
+        "role": "Developer",
+        "skills": ["JavaScript", "Python"]
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case027.json
+++ b/test/test-suite/groups/function-removeEmpty/case027.json
@@ -1,0 +1,9 @@
+{
+    "expr": "$removeEmpty(data.objects.partial, [\"empty_string\"], false)",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "valid": "data",
+        "empty_string": ""
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case028.json
+++ b/test/test-suite/groups/function-removeEmpty/case028.json
@@ -1,0 +1,10 @@
+{
+    "expr": "$removeEmpty(organization.departments[0].budget, [\"remaining\"], true)",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "allocated": 100000,
+        "spent": 0,
+        "remaining": null
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case029.json
+++ b/test/test-suite/groups/function-removeEmpty/case029.json
@@ -1,0 +1,11 @@
+{
+    "expr": "{\"cleaned_projects\": $map(user.projects[name != \"\"], function($proj) { $removeEmpty($proj.metadata) }), \"department_count\": $count(organization.departments)}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "cleaned_projects": {
+            "created": "2023-01-15"
+        },
+        "department_count": 2
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case030.json
+++ b/test/test-suite/groups/function-removeEmpty/case030.json
@@ -1,0 +1,18 @@
+{
+    "expr": "organization.departments.{\"name\": name, \"clean_employees\": $map(employees[name != \"\"], function($emp) { $removeEmpty($emp) })}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": [
+        {
+            "name": "Engineering",
+            "clean_employees": {
+                "name": "Alice Smith",
+                "role": "Developer",
+                "skills": ["JavaScript", "Python"]
+            }
+        },
+        {
+            "name": ""
+        }
+    ]
+}

--- a/test/test-suite/groups/function-removeEmpty/case031.json
+++ b/test/test-suite/groups/function-removeEmpty/case031.json
@@ -1,0 +1,8 @@
+{
+    "expr": "data.arrays.nested[value != \"\"].{\"item_id\": id, \"cleaned_meta\": $removeEmpty(meta, [\"flags\"])}",
+    "dataset": "dataset26",
+    "bindings": {},
+    "result": {
+        "item_id": 1
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case032.json
+++ b/test/test-suite/groups/function-removeEmpty/case032.json
@@ -1,0 +1,13 @@
+{
+    "expr": "user.{\"profile_clean\": $removeEmpty(profile.social), \"settings_clean\": $removeEmpty(settings.features, [], true)}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "profile_clean": {
+            "linkedin": "https://linkedin.com/in/johndoe"
+        },
+        "settings_clean": {
+            "beta": false
+        }
+    }
+}

--- a/test/test-suite/groups/function-removeEmpty/case033.json
+++ b/test/test-suite/groups/function-removeEmpty/case033.json
@@ -1,0 +1,6 @@
+{
+    "expr": "data.objects.nested.level1.$removeEmpty().level2.$removeEmpty()",
+    "dataset": "dataset26",
+    "bindings": {},
+    "undefinedResult": true
+}

--- a/test/test-suite/groups/function-removeEmpty/case034.json
+++ b/test/test-suite/groups/function-removeEmpty/case034.json
@@ -1,0 +1,12 @@
+{
+    "expr": "user.projects[0].{\"name\": name, \"meta\": $removeEmpty(metadata, [\"updated\"], true)}",
+    "dataset": "dataset25",
+    "bindings": {},
+    "result": {
+        "name": "Project Alpha",
+        "meta": {
+            "created": "2023-01-15",
+            "updated": null
+        }
+    }
+}


### PR DESCRIPTION
Many schemas are configured to not allow empty objects, arrays or NULL values.
When writing JSONata scripts to generate output, it can be challenging to write conditional logic that checks whether or not deeply nested arrays/objects actually have data to generate without creating a lot of duplicate logic checks.

The removeEmpty function allows you to wrap any block of JSONata code to recursively process the results and remove empty arrays, objects, null values and optionally, empty strings.

This Pull Request contains updates to the documentation as well as a comprehensive suite of tests. 

Signed-off-by: Eric Litwin <elitwin.rm@gmail.com>
