### PR TITLE
Issues-767: change the 'each' signature to work with arrays

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -1916,7 +1916,7 @@ var jsonata = (function() {
     staticFrame.bind('spread', defineFunction(fn.spread, '<x-:a<o>>'));
     staticFrame.bind('merge', defineFunction(fn.merge, '<a<o>:o>'));
     staticFrame.bind('reverse', defineFunction(fn.reverse, '<a:a>'));
-    staticFrame.bind('each', defineFunction(fn.each, '<o-f:a>'));
+    staticFrame.bind('each', defineFunction(fn.each, '<(ao)-f:a>'));
     staticFrame.bind('error', defineFunction(fn.error, '<s?:x>'));
     staticFrame.bind('assert', defineFunction(fn.assert, '<bs?:x>'));
     staticFrame.bind('type', defineFunction(fn.type, '<x:s>'));

--- a/test/test-suite/groups/function-each/case003.json
+++ b/test/test-suite/groups/function-each/case003.json
@@ -1,0 +1,7 @@
+{
+    "expr": "$each([123, 321], function($v) {$v})",
+    "data": {},
+    "bindings": {},
+    "result": [123, 321],
+    "unordered": true
+}

--- a/test/test-suite/groups/function-each/case004.json
+++ b/test/test-suite/groups/function-each/case004.json
@@ -1,0 +1,7 @@
+{
+    "expr": "[123, 321] ~> $each(?, function($v) {$v})",
+    "data": {},
+    "bindings": {},
+    "result": [123, 321],
+    "unordered": true
+}


### PR DESCRIPTION
Change 'each' signature for correct work by docs. (https://github.com/jsonata-js/jsonata/issues/767)
Docs say: https://docs.jsonata.org/programming
```
Invocation chaining
value ~> $funcA ~> $funcB
is equivalent to
$funcB($funcA(value))
```
fix it for 'each' method
now 
`$each([123, 321], function($v) {$v})` and `[123, 321] ~> $each(?, function($v) {$v})` are equivalent 

Signed-off-by: Sergeev Viktor [sergeevviktor017@gmail.com](mailto:sergeevviktor017@gmail.com)