### PR TITLE
Fix ?? operator with array predicate on LHS

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -585,7 +585,7 @@ const parser = (() => {
                 type: 'function',
                 value: '(',
                 procedure: { type: 'variable', value: 'exists' },
-                arguments: [left]
+                arguments: [JSON.parse(JSON.stringify(left))]
             };
             this.then = left;
             this.else = expression(0);

--- a/test/test-suite/groups/coalescing-operator/case013.json
+++ b/test/test-suite/groups/coalescing-operator/case013.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs exists, should return lhs value",
+    "expr": "foo.blah[0] ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {"baz": {"fud": "hello"}}
+}

--- a/test/test-suite/groups/coalescing-operator/case014.json
+++ b/test/test-suite/groups/coalescing-operator/case014.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs does not exist, should return rhs value",
+    "expr": "foo.blah[5] ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}


### PR DESCRIPTION
## Summary

- Fix the `??` (nullish coalescing) operator returning incorrect results when the LHS
  contains an array predicate (e.g. `array[1] ?? 3`)
- The parser's `??` handler reused the same `left` AST node reference for both the
  `$exists()` condition and the `then` branch, causing filter stages to be duplicated
  during AST post-processing
- Deep-clone `left` for the condition argument so the two branches have independent
  AST nodes

Fixes #773

## Test plan

- [x] Added test case for LHS predicate that exists (case013)
- [x] Added test case for LHS predicate that doesn't exist (case014)
- [x] All 1763 tests passing

Signed-off-by: Jolse Maginnis <doolse@gmail.com>