### PR TITLE
Add Node.js 24 to testing

### DIFF
--- a/.github/workflows/jsonata.yml
+++ b/.github/workflows/jsonata.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v3
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: Install and build
         run: npm install && npm test
       - name: Publish to NPM
@@ -47,10 +47,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v3
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: Build documentation
         run: |
           cd website


### PR DESCRIPTION
Adds Node.js 24.x to the testing matrix, given it has been the LTS version since last October.

Also switches to using it as the version for other actions as the current active LTS.