### PR TITLE
Fix ?: operator returning wrong result when LHS has array predicate

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -878,7 +878,12 @@ const parser = (() => {
         // elvis/default operator
         infix("?:", operators['?:'], function (left) {
             this.type = 'condition';
-            this.condition = left;
+            // Deep-clone `left` so the condition and then branches have
+            // independent AST nodes. Sharing the same reference causes
+            // post-parse processing (e.g. predicate stages, unary minus
+            // folding on number literals) to mutate the same node twice,
+            // producing wrong results (see #773 for the equivalent ?? fix).
+            this.condition = JSON.parse(JSON.stringify(left));
             this.then = left;
             this.else = expression(0);
             return this;

--- a/test/test-suite/groups/default-operator/case014.json
+++ b/test/test-suite/groups/default-operator/case014.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs exists, should return lhs value",
+    "expr": "foo.blah[0] ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {"baz": {"fud": "hello"}}
+}

--- a/test/test-suite/groups/default-operator/case015.json
+++ b/test/test-suite/groups/default-operator/case015.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs does not exist, should return rhs value",
+    "expr": "foo.blah[5] ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/test/test-suite/groups/default-operator/case016.json
+++ b/test/test-suite/groups/default-operator/case016.json
@@ -1,0 +1,7 @@
+{
+    "description": "negative array index on lhs returns last element",
+    "expr": "[1,2,3][-1] ?: 42",
+    "dataset": null,
+    "bindings": {},
+    "result": 3
+}

--- a/test/test-suite/groups/default-operator/case017.json
+++ b/test/test-suite/groups/default-operator/case017.json
@@ -1,0 +1,7 @@
+{
+    "description": "negative array index on single-element array returns the element",
+    "expr": "[true][-1] ?: \"no\"",
+    "dataset": null,
+    "bindings": {},
+    "result": true
+}

--- a/test/test-suite/groups/default-operator/case018.json
+++ b/test/test-suite/groups/default-operator/case018.json
@@ -1,0 +1,7 @@
+{
+    "description": "unary minus on number literal LHS is not double-negated",
+    "expr": "-5 ?: 99",
+    "dataset": null,
+    "bindings": {},
+    "result": -5
+}


### PR DESCRIPTION
## Quick Note

We are using JSONata quite extensively over at Ambivio and love it!
But we have noticed some issues like this one.

Please review these changes carefully as they have been AI-assisted and I don't have a deep understanding of JSONatas parsing logic.

## Summary

The `?:` (elvis/default) operator returns the wrong value whenever its left-hand side is an array predicate or a negative numeric literal. For example:

| Expression | Expected | Actual (before fix) |
|---|---|---|
| `[true][-1] ?: "no"` | `true` | `"no"` |
| `[1,2,3][-1] ?: "no"` | `3` | `2` |
| `array[1] ?: "no"` (with `array=[10,20]`) | `20` | `"no"` |
| `-5 ?: 99` | `-5` | `5` |

## Root cause

In `src/parser.js`, the `?:` infix handler stored the same `left` AST node reference into both `condition` and `then`:

```js
infix("?:", operators['?:'], function (left) {
    this.type = 'condition';
    this.condition = left;
    this.then = left;        // SAME REFERENCE
    this.else = expression(0);
    return this;
});
```

The post-parse `processAST` step then walks both branches, but `processAST` mutates the AST it receives:

- The `[` (predicate) handler pushes a `filter` stage onto the LHS step. Run twice on the same node, you get two filters — so `array[1]` becomes effectively `array[1][1]`.
- The unary-`-` handler folds `-N` into the underlying number literal by mutating its `value` in place. Run twice, the negation is undone — so `-5` becomes `5`.

This is the exact same class of bug that was fixed for the `??` operator in #774 / commit fd47061 (closing #773). The fix was never propagated to `?:`.

## Fix

Deep-clone `left` for the `condition` branch so the two branches have independent AST nodes — mirroring the `??` fix:

```js
infix("?:", operators['?:'], function (left) {
    this.type = 'condition';
    this.condition = JSON.parse(JSON.stringify(left));
    this.then = left;
    this.else = expression(0);
    return this;
});
```

## Tests

Added 5 new test cases under `test/test-suite/groups/default-operator/`:

- `case014.json` — array predicate on LHS exists, returns LHS value
- `case015.json` — array predicate on LHS does not exist, returns RHS value
- `case016.json` — negative array index on multi-element array
- `case017.json` — negative array index on single-element array
- `case018.json` — unary minus on number literal LHS is not double-negated

Full suite passes locally: **1768 passing, 100% coverage** maintained.

## Test plan

- [x] `npm test` passes (1768 tests)
- [x] 100% coverage maintained
- [x] All cases from the linked issue return correct values
- [x] Existing `default-operator` tests still pass

Signed-off-by: Leo Garbe <leo@respark.dev>
