### PR TITLE
fix $toMillis() with more than 3 digit fractional seconds

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -994,6 +994,11 @@ const dateTime = (function () {
                         }
                         return offsetHours * 60 + offsetMinutes;
                     };
+                } else if (part.component === 'f') {
+                    res.regex = '[0-9]+';
+                    res.parse = function(value) {
+                        return parseFloat('0.' + value.substring(0, 3)) * 1000;
+                    };
                 } else if (part.integerFormat) {
                     res = generateRegex(part.integerFormat);
                 } else {

--- a/test/test-suite/groups/function-tomillis/parseDateTime.json
+++ b/test/test-suite/groups/function-tomillis/parseDateTime.json
@@ -366,5 +366,13 @@
         "expr": "$toMillis('2020-09-09 12:00:00 +0530', '[Y0001]-[M01]-[D01] [H01]:[m01]:[s01] [Z0001]') ~> $fromMillis() ",
         "data": {},
         "result": "2020-09-09T06:30:00.000Z"
+    },
+    {
+        "function": "#toMillis",
+        "category": "timezones",
+        "description": "should correctly parse fractional seconds of more than 3 digits, and truncate to millis",
+        "expr": "$toMillis('2026-04-08T19:05:04.01987', '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01].[f1]') ~> $fromMillis() ",
+        "data": {},
+        "result": "2026-04-08T19:05:04.019Z"
     }
 ]


### PR DESCRIPTION
The factional part of the date/time seconds was being parsed and converted to an integer in order to pass to the milliseconds parameter. However, if there were more than 3 digits, then this would be more than a thousand and spill over into the seconds (and possible minutes).
Moreover, if the fractional part started with a zero, this would get lost in the conversion to an integer. This commit fixes the parsing and truncates the value to max 3 digits (milliseconds is the finest resolution supported).

resolves #778 