### PR TITLE
fix picture string parsing for $formatNumber

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -825,6 +825,7 @@ const functions = (() => {
                         return subpicture.substring(0, ii);
                     }
                 }
+                return "";
             })();
             var suffix = (function () {
                 var ch;
@@ -834,6 +835,7 @@ const functions = (() => {
                         return subpicture.substring(ii + 1);
                     }
                 }
+                return "";
             })();
             var activePart = subpicture.substring(prefix.length, subpicture.length - suffix.length);
             var mantissaPart, exponentPart, integerPart, fractionalPart;

--- a/test/test-suite/groups/function-formatNumber/issue786.json
+++ b/test/test-suite/groups/function-formatNumber/issue786.json
@@ -1,0 +1,26 @@
+[
+    {
+        "expr": "$formatNumber(42, '%%')",
+        "dataset": null,
+        "bindings": {},
+        "code": "D3086"
+    },
+    {
+        "expr": "$formatNumber(42, '‰‰')",
+        "dataset": null,
+        "bindings": {},
+        "code": "D3086"
+    },
+    {
+        "expr": "$formatNumber(42, '%‰')",
+        "dataset": null,
+        "bindings": {},
+        "code": "D3086"
+    },
+    {
+        "expr": "$formatNumber(42, '---')",
+        "dataset": null,
+        "bindings": {},
+        "code": "D3086"
+    }
+]


### PR DESCRIPTION
In `$formatNumber()`, if a picture string part contains no prefix or suffix, the parsing code should assign an empty string, which will subsequently throw error D3086. Instead it is leaking the Javascript error attempting to get the length of an undefined value.

resolved #786 