### PR TITLE
Update jsonata-java version compatibilty

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -29,7 +29,7 @@ The following are known implementations of JSONata in addition to the primary im
 |Go|https://github.com/blues/jsonata-go|Native implementation|1.5.4|
 |Go|https://github.com/yxuco/gojsonata|Native implementation| |
 |Java|https://github.com/IBM/JSONata4Java|Native implementation| |
-|Java|https://github.com/dashjoin/jsonata-java|Native port of reference|2.0.5|
+|Java|https://github.com/dashjoin/jsonata-java|Native port of reference|2.1.0|
 |.NET|https://github.com/mikhail-barg/jsonata.net.native|Native implementation|2.1.0|
 |Python|https://github.com/qlyoung/pyjsonata|API bindings based on C bindings|1.8.3|
 |Python|https://github.com/rayokota/jsonata-python|Native port of reference|2.1.0|


### PR DESCRIPTION
Released new version
https://github.com/dashjoin/jsonata-java

https://central.sonatype.com/artifact/com.dashjoin/jsonata