### PR TITLE
Fix $formatNumber infinite loop on zero/negative values with exponent (#785)

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1074,13 +1074,21 @@ const functions = (() => {
             var minMantissa = Math.pow(10, pic.scalingFactor - 1);
             mantissa = adjustedNumber;
             exponent = 0;
-            while (mantissa < minMantissa) {
-                mantissa *= 10;
-                exponent -= 1;
-            }
-            while (mantissa > maxMantissa) {
-                mantissa /= 10;
-                exponent += 1;
+            // Compare magnitudes; previously `mantissa < minMantissa` was
+            // true for every negative mantissa and `0 * 10 === 0` never
+            // crossed the threshold, producing an infinite loop on zero
+            // and negative inputs (#785). For zero the desired exponent is
+            // simply zero — the XPath F&O Bullet 5 says "if N is zero, set
+            // M to zero and E to zero".
+            if (mantissa !== 0) {
+                while (Math.abs(mantissa) < minMantissa) {
+                    mantissa *= 10;
+                    exponent -= 1;
+                }
+                while (Math.abs(mantissa) > maxMantissa) {
+                    mantissa /= 10;
+                    exponent += 1;
+                }
             }
         }
         // bullet 6:

--- a/test/test-suite/groups/function-formatNumber/issue785.json
+++ b/test/test-suite/groups/function-formatNumber/issue785.json
@@ -1,0 +1,26 @@
+[
+    {
+        "expr": "$formatNumber(0, '0e0')",
+        "dataset": null,
+        "bindings": {},
+        "result": "0e0"
+    },
+    {
+        "expr": "$formatNumber(-42, '0e0')",
+        "dataset": null,
+        "bindings": {},
+        "result": "-4e1"
+    },
+    {
+        "expr": "$formatNumber(42, '0e0')",
+        "dataset": null,
+        "bindings": {},
+        "result": "4e1"
+    },
+    {
+        "expr": "$formatNumber(0, '0.00e0')",
+        "dataset": null,
+        "bindings": {},
+        "result": "0.00e0"
+    }
+]


### PR DESCRIPTION
Closes #785.

`$formatNumber(0, "0e0")` and `$formatNumber(-42, "0e0")` hang forever. The mantissa-adjustment loops in `formatNumber` (src/functions.js) compare raw signed mantissa values against the magnitude thresholds:

```js
while (mantissa < minMantissa) { mantissa *= 10; exponent -= 1; }
while (mantissa > maxMantissa) { mantissa /= 10; exponent += 1; }
```

For zero, `0 * 10 === 0` so `mantissa < 1` stays true and `exponent` underflows toward `-Infinity` without yielding to the event loop. For any negative input, `mantissa < 1` is trivially true (negatives are always less than the positive minimum).

Per XPath F&O 4.7.3 Bullet 5 the loops are meant to normalise the **magnitude** of the mantissa and the sign is already handled separately via the second sub-picture prefix. Switch the comparisons to `Math.abs(mantissa)` and short-circuit when `mantissa === 0`.

Regression test `test/test-suite/groups/function-formatNumber/issue785.json` covers zero, negative, positive, and zero-with-fractional cases — all hang on `master` (verified by interrupting an `npx mocha --grep issue785` run that ran for tens of seconds without producing output) and pass after the fix.
