### PR TITLE
Wildcards should not unwrap function objects

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -606,7 +606,7 @@ var jsonata = (function() {
         if (Array.isArray(input) && input.outerWrapper && input.length > 0) {
             input = input[0];
         }
-        if (input !== null && typeof input === 'object') {
+        if (input !== null && typeof input === 'object' && !isFunction(input)) {
             Object.keys(input).forEach(function (key) {
                 var value = input[key];
                 if(Array.isArray(value)) {
@@ -677,7 +677,7 @@ var jsonata = (function() {
             input.forEach(function (member) {
                 recurseDescendants(member, results);
             });
-        } else if (input !== null && typeof input === 'object') {
+        } else if (input !== null && typeof input === 'object' && !isFunction(input)) {
             Object.keys(input).forEach(function (key) {
                 recurseDescendants(input[key], results);
             });

--- a/test/test-suite/groups/wildcards/case010.json
+++ b/test/test-suite/groups/wildcards/case010.json
@@ -1,0 +1,20 @@
+[
+    {
+        "expr": "$sum.*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    },
+    {
+        "expr": "[$sum, $count].*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    },
+    {
+        "expr": "/a/.*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    }
+]


### PR DESCRIPTION
Prevent * and ** from exposing the internals of a lambda object.