### PR TITLE
Fix $contains crash when the token is undefined

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -342,7 +342,7 @@ const functions = (() => {
      */
     async function contains(str, token) {
         // undefined inputs always return undefined
-        if (typeof str === 'undefined') {
+        if (typeof str === 'undefined' || typeof token === 'undefined') {
             return undefined;
         }
 

--- a/test/test-suite/groups/function-contains/case007.json
+++ b/test/test-suite/groups/function-contains/case007.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$contains(\"Hello World\", nothing)",
+    "dataset": null,
+    "bindings": {},
+    "undefinedResult": true
+}


### PR DESCRIPTION
`$contains("Hello World", nothing)` throws instead of returning undefined. Any time the second arg resolves to undefined it slips past the string check into the regex-matcher branch and calls `.apply` on undefined. `contains` already returns undefined when `str` is undefined, so I just extended that guard to the token too.

Heads up: `$split` and `$replace` share the same `evaluateMatcher` path and blow up the same way (`$match` is fine, its signature rejects undefined first). I kept this scoped to `$contains`. If you'd rather squash all three at once, a guard inside `evaluateMatcher` would do it, but that's a wider change so I left it to you.

Added a test case that goes fail -> pass with the change, full suite green at 100% coverage.

closes #584

Signed-off-by: Apoorva Verma <vermaapoorva0510@gmail.com>
