### PR TITLE
Fix $each throwing on undefined input

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1827,6 +1827,11 @@ const functions = (() => {
      * @returns {Array} - the resultant array
      */
     async function each(obj, func) {
+        // undefined inputs always return undefined
+        if (typeof obj === 'undefined') {
+            return undefined;
+        }
+
         var result = this.createSequence();
 
         for (const key of Object.keys(obj)) {

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -423,6 +423,12 @@ describe("Tests that bind Javascript functions", () => {
             var expected = [1, 2, 3, 4];
             expect(result).to.deep.equal(expected);
         });
+
+        it("should return undefined when the input is undefined", async function() {
+            var expr = jsonata("$each(input.data, function($v, $k) { $v })");
+            var result = await expr.evaluate({ input: {}, output: {} });
+            expect(result).to.deep.equal(undefined);
+        });
     });
 
     describe("Partially apply user-defined Javascript function", function() {


### PR DESCRIPTION
## Description

`$each` throws `TypeError: Cannot convert undefined or null to object` when
its first argument evaluates to undefined, for example `$each(input.data, ...)`
where `input.data` does not exist.

JSONata treats undefined as a silent no-op, and the sibling higher-order
functions (`$map`, `$filter`, `$single`) all short-circuit and return undefined
for undefined input. `$each` was missing the same guard, so it regressed
between 2.1.1 (no-op) and 2.2.1 (throws).

This adds the same undefined check used by the sibling functions so `$each`
returns undefined instead of throwing.

## Testing

Added a regression test in `test/implementation-tests.js` that evaluates
`$each(input.data, function($v, $k) { $v })` against `{ input: {}, output: {} }`
and expects `undefined`. It fails on the current code with the reported
TypeError and passes with the fix. Full test suite passes and 100% coverage is
maintained.

Signed-off-by: Rup Sarmah <sarmah.rup@gmail.com>

Closes #812
