### PR TITLE
Backport important security fixes to v1

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1053,7 +1053,7 @@ const dateTime = (function () {
                     };
                     break;
                 case formats.WORDS:
-                    matcher.regex = '(?:' + Object.keys(wordValues).concat('and', '[\\-, ]').join('|') + ')+';
+                    matcher.regex = '(?:' + utils.keys(wordValues).concat('and', '[\\-, ]').join('|') + ')+';
                     matcher.parse = function (value) {
                         return wordsToNumber(value.toLowerCase());
                     };

--- a/src/functions.js
+++ b/src/functions.js
@@ -791,7 +791,7 @@ const functions = (() => {
         // if `options` is specified, then its entries override defaults
         var properties = defaults;
         if (typeof options !== 'undefined') {
-            Object.keys(options).forEach(function (key) {
+            utils.keys(options).forEach(function (key) {
                 properties[key] = options[key];
             });
         }
@@ -1418,7 +1418,7 @@ const functions = (() => {
                 result = true;
             }
         } else if (arg !== null && typeof arg === 'object') {
-            if (Object.keys(arg).length > 0) {
+            if (utils.keys(arg).length > 0) {
                 result = true;
             }
         } else if (typeof arg === 'boolean' && arg === true) {
@@ -1657,7 +1657,7 @@ const functions = (() => {
             });
             result = keys(merge);
         } else if (arg !== null && typeof arg === 'object' && !(isLambda(arg))) {
-            Object.keys(arg).forEach(key => result.push(key));
+            utils.keys(arg).forEach(key => result.push(key));
         }
         return result;
     }
@@ -1683,7 +1683,7 @@ const functions = (() => {
                     }
                 }
             }
-        } else if (input !== null && typeof input === 'object') {
+        } else if (input !== null && typeof input === 'object' && Object.prototype.hasOwnProperty.call(input, key) && !isFunction(input)) {
             result = input[key];
         }
         return result;
@@ -1740,7 +1740,7 @@ const functions = (() => {
                 result = append(result, spread(item));
             });
         } else if (arg !== null && typeof arg === 'object' && !isLambda(arg)) {
-            for (const key of Object.keys(arg)) {
+            for (const key of utils.keys(arg)) {
                 var obj = Object.create(null);
                 obj[key] = arg[key];
                 result.push(obj);
@@ -1766,7 +1766,7 @@ const functions = (() => {
         var result = Object.create(null);
 
         arg.forEach(function (obj) {
-            for (const prop of Object.keys(obj)) {
+            for (const prop of utils.keys(obj)) {
                 result[prop] = obj[prop];
             }
         });
@@ -1806,7 +1806,7 @@ const functions = (() => {
     function* each(obj, func) {
         var result = createSequence();
 
-        for (const key of Object.keys(obj)) {
+        for (const key of utils.keys(obj)) {
             var func_args = hofFuncArgs(func, obj[key], key, obj);
             // invoke func
             var val = yield* func.apply(this, func_args);
@@ -2035,7 +2035,7 @@ const functions = (() => {
     function* sift(arg, func) {
         var result = Object.create(null);
 
-        for (const item of Object.keys(arg)) {
+        for (const item of utils.keys(arg)) {
             var entry = arg[item];
             var func_args = hofFuncArgs(func, entry, item, arg);
             // invoke func
@@ -2046,7 +2046,7 @@ const functions = (() => {
         }
 
         // empty objects should be changed to undefined
-        if (Object.keys(result).length === 0) {
+        if (utils.keys(result).length === 0) {
             result = undefined;
         }
 

--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -235,7 +235,7 @@ var jsonata = (function() {
 
     function createFrameFromTuple(environment, tuple) {
         var frame = createFrame(environment);
-        for(const prop of Object.keys(tuple)) {
+        for(const prop of utils.keys(tuple)) {
             frame.bind(prop, tuple[prop]);
         }
         return frame;
@@ -600,8 +600,8 @@ var jsonata = (function() {
         if (Array.isArray(input) && input.outerWrapper && input.length > 0) {
             input = input[0];
         }
-        if (input !== null && typeof input === 'object') {
-            Object.keys(input).forEach(function (key) {
+        if (input !== null && typeof input === 'object' && !isFunction(input)) {
+            utils.keys(input).forEach(function (key) {
                 var value = input[key];
                 if(Array.isArray(value)) {
                     value = flatten(value);
@@ -671,8 +671,8 @@ var jsonata = (function() {
             Array.prototype.forEach.call(input, function (member) {
                 recurseDescendants(member, results);
             });
-        } else if (input !== null && typeof input === 'object') {
-            Object.keys(input).forEach(function (key) {
+        } else if (input !== null && typeof input === 'object' && !isFunction(input)) {
+            utils.keys(input).forEach(function (key) {
                 recurseDescendants(input[key], results);
             });
         }
@@ -932,6 +932,16 @@ var jsonata = (function() {
                 }
 
                 if (key !== undefined) {
+                    // reject any attempts to set the internal JSONata flags
+                    if (key === '_jsonata_lambda' || key === '_jsonata_function') {
+                        // this is a restriction of this implementation rather than JSONata itself
+                        throw {
+                            code: "D1013",
+                            stack: (new Error()).stack,
+                            position: expr.position,
+                            value: key
+                        };
+                    }
                     var entry = {data: item, exprIndex: pairIndex};
                     if (Object.prototype.hasOwnProperty.call(groups, key)) {
                         // a value already exists in this slot
@@ -982,7 +992,7 @@ var jsonata = (function() {
         var result = Object.create(null);
         Object.assign(result, tupleStream[0]);
         for(var ii = 1; ii < tupleStream.length; ii++) {
-            for(const prop of Object.keys(tupleStream[ii])) {
+            for(const prop of utils.keys(tupleStream[ii])) {
                 result[prop] = fn.append(result[prop], tupleStream[ii][prop]);
             }
         }
@@ -1295,13 +1305,6 @@ var jsonata = (function() {
                 }
                 for(var ii = 0; ii < matches.length; ii++) {
                     var match = matches[ii];
-                    if (match && (match.isPrototypeOf(result) || match instanceof Object.constructor)) {
-                        throw {
-                            code: "D1010",
-                            stack: (new Error()).stack,
-                            position: expr.position
-                        };
-                    }
                     // evaluate the update value for each match
                     var update = yield * evaluate(expr.update, match, environment);
                     // update must be an object
@@ -1317,7 +1320,7 @@ var jsonata = (function() {
                             };
                         }
                         // merge the update
-                        for(const prop of Object.keys(update)) {
+                        for(const prop of utils.keys(update)) {
                             match[prop] = update[prop];
                         }
                     }
@@ -1978,7 +1981,7 @@ var jsonata = (function() {
         "T1007": "Attempted to partially apply a non-function. Did you mean ${{{token}}}?",
         "T1008": "Attempted to partially apply a non-function",
         "D1009": "Multiple key definitions evaluate to same key: {{value}}",
-        "D1010": "Attempted to access the Javascript object prototype", // Javascript specific 
+        "D1013": "Object property names starting with _jsonata_ are reserved for internal use: {{value}}",
         "T1010": "The matcher function argument passed to function {{token}} does not return the correct object structure",
         "T2001": "The left side of the {{token}} operator must evaluate to a number",
         "T2002": "The right side of the {{token}} operator must evaluate to a number",
@@ -2113,7 +2116,7 @@ var jsonata = (function() {
                     var exec_env;
                     // the variable bindings have been passed in - create a frame to hold these
                     exec_env = createFrame(environment);
-                    for (const v of Object.keys(bindings)) {
+                    for (const v of utils.keys(bindings)) {
                         exec_env.bind(v, bindings[v]);
                     }
                 } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -189,6 +189,15 @@ const utils = (() => {
         return arr;
     }
 
+    /**
+     *
+     * @param {Object} arg - the object to inspect
+     * @returns {Array} - the keys (property names) of the object
+     */
+    function keys(arg) {
+        return typeof arg === 'object' && arg !== null ? Object.keys(arg) : [];
+    }
+
     return {
         isNumeric,
         isArrayOfStrings,
@@ -200,7 +209,8 @@ const utils = (() => {
         isIterable,
         getFunctionArity,
         isDeepEqual,
-        stringToArray
+        stringToArray,
+        keys
     };
 })();
 

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -806,30 +806,42 @@ describe("Tests that are specific to a Javascript runtime", () => {
             });
         });
     });
-    describe("Expressions that attempt to pollute the object prototype", function() {
-        it("should throw an error with __proto__", async function() {
-            const expr = jsonata('{} ~> | __proto__ | {"is_admin": true} |');
+    describe("Expressions that attempt to access the object prototype", function() {
+        const data = {"foo": {"bar": "baz"}};
+        it("should ignore __proto__", function() {
+            const expr = jsonata('foo.__proto__');
+            const result = expr.evaluate(data);
+            expect(result).to.deep.equal(undefined);
+        });
+
+        it("should throw an error trying to invoke toString()", function() {
+            const expr = jsonata('foo.toString()');
             expect(function() {
-                expr.evaluate();
+                expr.evaluate(data);
             })
                 .to.throw()
-                .to.deep.contain({ position: 7, code: "D1010" });
+                .to.deep.contain({ position: 13, code: "T1006" });
         });
-        it("should throw an error with __lookupGetter__", async function() {
+    });
+
+    describe("Expressions that attempt to pollute the object prototype", function() {
+        it("should ignore __proto__", function() {
+            const expr = jsonata('{} ~> | __proto__ | {"is_admin": true} |');
+            const result = expr.evaluate();
+            expect(result).to.deep.equal({});
+        });
+        it("should throw an error with __lookupGetter__", function() {
             const expr = jsonata('{} ~> | __lookupGetter__("__proto__")() | {"is_admin": true} |');
             expect(function() {
                 expr.evaluate();
             })
                 .to.throw()
-                .to.deep.contain({ position: 7, code: "D1010" });
+                .to.deep.contain({ position: 25, code: "T1006" });
         });
-        it("should throw an error with constructor", async function() {
+        it("should ignore constructor", function() {
             const expr = jsonata('{} ~> | constructor | {"is_admin": true} |');
-            expect(function() {
-                expr.evaluate();
-            })
-                .to.throw()
-                .to.deep.contain({ position: 7, code: "D1010" });
+            const result = expr.evaluate();
+            expect(result).to.deep.equal({});
         });
     });
 });
@@ -870,6 +882,25 @@ describe("Tests that include infinite recursion", () => {
                 .to.throw()
                 .to.deep.contain({ token: "inf", code: "U1001" });
         });
+    });
+});
+
+describe("Tests invalid object creation", function() {
+    it("prevents creating an object mimicking a lambda", function() {
+        expect(function() {
+            var expr = jsonata('($lambda = {"_jsonata_lambda": true}; $lambda())');
+            expr.evaluate();
+        })
+            .to.throw()
+            .to.deep.contain({ code: "D1013" });
+    });
+    it("prevents creating an object mimicking a function", function() {
+        expect(function() {
+            var expr = jsonata('($fn = {"_jsonata_function": true}; $fn())');
+            expr.evaluate();
+        })
+            .to.throw()
+            .to.deep.contain({ code: "D1013" });
     });
 });
 

--- a/test/test-suite/groups/function-each/case003.json
+++ b/test/test-suite/groups/function-each/case003.json
@@ -1,0 +1,5 @@
+{
+    "expr": "$each(input.data, function($v, $k) {$v})",
+    "data": { "input": {}, "output": {} },
+    "undefinedResult": true
+}

--- a/test/test-suite/groups/wildcards/case010.json
+++ b/test/test-suite/groups/wildcards/case010.json
@@ -1,0 +1,20 @@
+[
+    {
+        "expr": "$sum.*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    },
+    {
+        "expr": "[$sum, $count].*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    },
+    {
+        "expr": "/a/.*",
+        "data": {},
+        "bindings": {},
+        "undefinedResult": true
+    }
+]


### PR DESCRIPTION
Backport security fixes #794, #800 and #802 (#799 was previously backported), as well as #814 which fixed a regression related to these changes.

These are for https://github.com/jsonata-js/jsonata/security/advisories/GHSA-8gq3-vp5j-2grp, https://github.com/jsonata-js/jsonata/security/advisories/GHSA-2943-5xfg-gq5f and https://github.com/jsonata-js/jsonata/security/advisories/GHSA-66mm-25pp-rfff