### PR TITLE
race condition when `$$` used concurrently

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -2156,16 +2156,13 @@ var jsonata = (function() {
                     throw err;
                 }
 
-                if (typeof bindings !== 'undefined') {
-                    var exec_env;
-                    // the variable bindings have been passed in - create a frame to hold these
-                    exec_env = createFrame(environment);
-                    for (const v of utils.keys(bindings)) {
-                        exec_env.bind(v, bindings[v]);
-                    }
-                } else {
-                    exec_env = environment;
+                const exec_env = createFrame(environment);
+
+                // add any variable bindings may have been passed in
+                for (const v of utils.keys(bindings)) {
+                    exec_env.bind(v, bindings[v]);
                 }
+
                 // put the input document into the environment as the root object
                 exec_env.bind('$', input);
 

--- a/test/implementation-tests.js
+++ b/test/implementation-tests.js
@@ -1153,13 +1153,55 @@ describe("Tests that use internal frame push callbacks", () => {
     describe("frame push callback bound to expression", function()  {
         it("calls callback when new frame created", function(done) {
             var expr = jsonata("( )");
+            // gets called twice
+            let count = 0;
             expr.assign(Symbol.for('jsonata.__createFrame_push'), function(parentEnv, newEnv) {
                 expect(parentEnv).to.not.equal(newEnv);
                 expect(parentEnv).to.include.keys(['lookup', 'bind']);
                 expect(newEnv).to.include.keys(['lookup', 'bind']);
-                done();
+                count++;
+                if (count == 2) done();
             });
             expr.evaluate();
         });
     });
 });
+
+describe("Concurrency tests", () => {
+    it("invokes a single compiled expression multiple times concurrently", async () => {
+        const expression = `
+        {
+            "id": $$.id,
+            "delayed": $slow($$.id)
+        }`;
+
+
+        const compiled = jsonata(expression);
+
+        // Async user function — long-running on purpose.
+        compiled.registerFunction(
+            "slow",
+            async (id) => {
+                await new Promise((resolve) => setTimeout(resolve, 20));
+                return `done:${id}`;
+            },
+            "<s:s>",
+        );
+
+        const inputs = [
+            { id: "a" },
+            { id: "b" },
+            { id: "c" },
+        ];
+
+        const results = await Promise.all(
+            inputs.map((input) => compiled.evaluate(input)),
+        );
+
+        expect(results).to.deep.equal([
+            {"id": "a", "delayed": "done:a"}, 
+            {"id": "b", "delayed": "done:b"}, 
+            {"id": "c", "delayed": "done:c"}
+        ])
+    })
+})


### PR DESCRIPTION
If the root variable reference `$$` is used in multiple concurrent invocations of a single compiled expression, then a race condition exists.  This is because the `$$` binding is stored in the global expression environment rather than the evaluation environment.

Resolves https://github.com/jsonata-js/jsonata/issues/804