### PR TITLE
correctly handle empty joins

### DIFF
--- a/src/jsonata.js
+++ b/src/jsonata.js
@@ -924,7 +924,7 @@ var jsonata = (function() {
             input = focus.createSequence(input);
         }
         // if the array is empty, add an undefined entry to enable literal JSON object to be generated
-        if (input.length === 0) {
+        if (input.length === 0 && !reduce) {
             input.push(undefined);
         }
 

--- a/test/test-suite/groups/joins/library-joins.json
+++ b/test/test-suite/groups/joins/library-joins.json
@@ -196,5 +196,25 @@
                 "customer": "10003"
             }
         ]
+    },
+    {
+        "expr-file": "library-joins011.jsonata",
+        "dataset": "library",
+        "bindings": {},
+        "result": {
+            "Joe Doe": [
+                "Structure and Interpretation of Computer Programs"
+            ],
+            "Jason Arthur": [
+                "Compilers: Principles, Techniques, and Tools",
+                "Structure and Interpretation of Computer Programs"
+            ]
+        }
+    },
+    {
+        "expr-file": "library-joins012.jsonata",
+        "dataset": "library",
+        "bindings": {},
+        "result": {}
     }
 ]

--- a/test/test-suite/groups/joins/library-joins011.jsonata
+++ b/test/test-suite/groups/joins/library-joins011.jsonata
@@ -1,0 +1,3 @@
+library.loans@$L.books@$B[$L.isbn=$B.isbn].customers[$L.customer=id]{
+  name: $B.title[]
+}

--- a/test/test-suite/groups/joins/library-joins012.jsonata
+++ b/test/test-suite/groups/joins/library-joins012.jsonata
@@ -1,0 +1,3 @@
+library.loans@$L.books@$B[$L.isbn=$B.isbn].customers[$L.customer='not found']{
+  name: $B.title[]
+}


### PR DESCRIPTION
If a join condition results in an empty object, an internal javascript error gets thrown back to the user.
Instead it should return an empty object.

Resolves https://github.com/jsonata-js/jsonata/issues/770