### PR TITLE
Strip the v off the tag name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Install and build
         run: npm install && npm test
       - name: Publish to NPM
-        run: npm publish --tag ${{ github.ref_name }}
+        run: npm publish --tag ${GITHUB_REF_NAME#v}


### PR DESCRIPTION
As title. Should mean we can publish the `v1.8.8` tag as `1.8.8` in NPM.

Local demo in shell:
```
export GITHUB_REF_NAME=v1.8.8
echo ${GITHUB_REF_NAME#v}
```